### PR TITLE
consistent format

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -39,13 +39,13 @@ class App extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            team:'ORL'
+            team: 'ORL'
         };
     }
 
     selectTeam(e) {
         var team = e.target.innerHTML
-        this.setState({team:team});
+        this.setState({ team: team });
     }
 
     render() {
@@ -67,7 +67,7 @@ class App extends Component {
                         data={avgSalaryYearData}
                         options={{
                             title: 'Average Salary in MLS',
-                            chartArea: {width: '50%'},
+                            chartArea: { width: '50%' },
                             isStacked: true,
                             hAxis: {
                                 title: 'Budget per row of positions',
@@ -112,7 +112,7 @@ class App extends Component {
                     <button className="dropbtn">{this.state.team} &#9660;</button>
                     <div className="dropdown-content">
                         {Object.keys(teams).map(team =>
-                            <a key={team+"Opt"} onClick={this.selectTeam.bind(this)}>{team}</a>
+                            <a key={team + "Opt"} onClick={this.selectTeam.bind(this)}>{team}</a>
                         )}
                     </div>
                 </div>
@@ -129,14 +129,14 @@ class App extends Component {
 
                 <div className="container">
                     {Object.keys(teams).map(team =>
-                        <div key={team+"max"} style={{marginTop:'3%', width:'28%'}}>
+                        <div key={team + "max"} style={{ marginTop: '3%', width: '28%' }}>
 
-                        <TeamCard
-                            team={team}
-                            budget={teams[team]["budget"]}
-                            player={teams[team]["salary_max_player"]}
-                            position={teams[team]["salary_max_position"]}
-                            salary={teams[team]["salary_max"]}/>
+                            <TeamCard
+                                team={team}
+                                budget={teams[team]["budget"]}
+                                player={teams[team]["salary_max_player"]}
+                                position={teams[team]["salary_max_position"]}
+                                salary={teams[team]["salary_max"]} />
                         </div>
                     )}
                 </div>

--- a/src/DataMLS.js
+++ b/src/DataMLS.js
@@ -1,2764 +1,2764 @@
 var data =
-[
-    {
-        "overall":{
-            "2016":{
-                "salary_avg":{
-                    "D":154934,
-                    "GK":140086,
-                    "M":326824,
-                    "F":448582
+    [
+        {
+            "overall": {
+                "2016": {
+                    "salary_avg": {
+                        "D": 154934,
+                        "GK": 140086,
+                        "M": 326824,
+                        "F": 448582
+                    },
+                    "salary_max": {
+                        "D": 1100000,
+                        "GK": 2100000,
+                        "M": 6660000,
+                        "F": 5610000
+                    },
+                    "salary_max_player": {
+                        "D": "Liam Ridgewell",
+                        "GK": "Tim Howard",
+                        "M": " Kaka",
+                        "F": "David Villa"
+                    }
                 },
-                "salary_max":{
-                    "D":1100000,
-                    "GK":2100000,
-                    "M":6660000,
-                    "F":5610000
+                "2015": {
+                    "salary_avg": {
+                        "D": 151395,
+                        "GK": 104927,
+                        "M": 324234,
+                        "F": 366905
+                    },
+                    "salary_max": {
+                        "D": 1200000,
+                        "GK": 360000,
+                        "M": 6660000,
+                        "F": 5610000
+                    },
+                    "salary_max_player": {
+                        "D": "Omar Gonzalez",
+                        "GK": "Bill Hamid",
+                        "M": " Kaka",
+                        "F": "David Villa"
+                    }
                 },
-                "salary_max_player":{
-                    "D":"Liam Ridgewell",
-                    "GK":"Tim Howard",
-                    "M":" Kaka",
-                    "F":"David Villa"
+                "2012": {
+                    "salary_avg": {
+                        "D": 135194,
+                        "GK": 77205,
+                        "M": 153540,
+                        "F": 212992
+                    },
+                    "salary_max": {
+                        "D": 4600000,
+                        "GK": 250000,
+                        "M": 3499999,
+                        "F": 5000000
+                    },
+                    "salary_max_player": {
+                        "D": "Rafael Marquez",
+                        "GK": "Donovan Ricketts",
+                        "M": "Tim Cahill",
+                        "F": "Thierry Henry"
+                    }
+                },
+                "2011": {
+                    "salary_avg": {
+                        "D": 115497,
+                        "GK": 95816,
+                        "M": 137005,
+                        "F": 193935
+                    },
+                    "salary_max": {
+                        "D": 4600000,
+                        "GK": 545460,
+                        "M": 5500000,
+                        "F": 5000000
+                    },
+                    "salary_max_player": {
+                        "D": "Rafael Marquez",
+                        "GK": "Frank Rost",
+                        "M": "David Beckham",
+                        "F": "Thierry Henry"
+                    }
+                },
+                "2010": {
+                    "salary_avg": {
+                        "D": 126678,
+                        "GK": 85948,
+                        "M": 155913,
+                        "F": 207187
+                    },
+                    "salary_max": {
+                        "D": 5544000,
+                        "GK": 300000,
+                        "M": 5500000,
+                        "F": 5000000
+                    },
+                    "salary_max_player": {
+                        "D": "Rafael Marquez",
+                        "GK": "Kasey Keller",
+                        "M": "David Beckham",
+                        "F": "Thierry Henry"
+                    }
+                },
+                "2017": {
+                    "salary_avg": {
+                        "D": 164165,
+                        "GK": 146472,
+                        "M": 347222,
+                        "F": 444797
+                    },
+                    "salary_max": {
+                        "D": 750000,
+                        "GK": 2000000,
+                        "M": 6660000,
+                        "F": 5610000
+                    },
+                    "salary_max_player": {
+                        "D": "Jonathan Mensah",
+                        "GK": "Tim Howard",
+                        "M": " Kaka",
+                        "F": "David Villa"
+                    }
+                },
+                "2008": {
+                    "salary_avg": {
+                        "D": 69087,
+                        "GK": 55478,
+                        "M": 139764,
+                        "F": 123219
+                    },
+                    "salary_max": {
+                        "D": 400000,
+                        "GK": 213000,
+                        "M": 5500000,
+                        "F": 1500000
+                    },
+                    "salary_max_player": {
+                        "D": "Dulio Davino",
+                        "GK": "Joe Cannon",
+                        "M": "David Beckham",
+                        "F": "Juan Pablo Angel"
+                    }
+                },
+                "2009": {
+                    "salary_avg": {
+                        "D": 75924,
+                        "GK": 66822,
+                        "M": 162359,
+                        "F": 136575
+                    },
+                    "salary_max": {
+                        "D": 255000,
+                        "GK": 300000,
+                        "M": 5500000,
+                        "F": 1500000
+                    },
+                    "salary_max_player": {
+                        "D": "Pablo Mastroeni",
+                        "GK": "Kasey Keller",
+                        "M": "David Beckham",
+                        "F": "Juan Pablo Angel"
+                    }
+                },
+                "2013": {
+                    "salary_avg": {
+                        "D": 107571,
+                        "GK": 85781,
+                        "M": 130985,
+                        "F": 244541
+                    },
+                    "salary_max": {
+                        "D": 331236,
+                        "GK": 275000,
+                        "M": 3500000,
+                        "F": 4913004
+                    },
+                    "salary_max_player": {
+                        "D": "Heath Pearce",
+                        "GK": "Donovan Ricketts",
+                        "M": "Tim Cahill",
+                        "F": "Clint Dempsey"
+                    }
+                },
+                "2014": {
+                    "salary_avg": {
+                        "D": 130434,
+                        "GK": 92862,
+                        "M": 220069,
+                        "F": 308964
+                    },
+                    "salary_max": {
+                        "D": 1200000,
+                        "GK": 260000,
+                        "M": 6660000,
+                        "F": 6000000
+                    },
+                    "salary_max_player": {
+                        "D": "Liam Ridgewell",
+                        "GK": "Donovan Ricketts",
+                        "M": " Kaka",
+                        "F": "Jermain Defoe"
+                    }
+                },
+                "2007": {
+                    "salary_avg": {
+                        "D": 68603,
+                        "GK": 56502,
+                        "M": 118814,
+                        "F": 132739
+                    },
+                    "salary_max": {
+                        "D": 280000,
+                        "GK": 220800,
+                        "M": 5500000,
+                        "F": 2492316
+                    },
+                    "salary_max_player": {
+                        "D": "Pablo Mastroeni",
+                        "GK": "Shaka Hislop",
+                        "M": "David Beckham",
+                        "F": "Cuauhtemoc Blanco"
+                    }
                 }
             },
-            "2015":{
-                "salary_avg":{
-                    "D":151395,
-                    "GK":104927,
-                    "M":324234,
-                    "F":366905
-                },
-                "salary_max":{
-                    "D":1200000,
-                    "GK":360000,
-                    "M":6660000,
-                    "F":5610000
-                },
-                "salary_max_player":{
-                    "D":"Omar Gonzalez",
-                    "GK":"Bill Hamid",
-                    "M":" Kaka",
-                    "F":"David Villa"
-                }
-            },
-            "2012":{
-                "salary_avg":{
-                    "D":135194,
-                    "GK":77205,
-                    "M":153540,
-                    "F":212992
-                },
-                "salary_max":{
-                    "D":4600000,
-                    "GK":250000,
-                    "M":3499999,
-                    "F":5000000
-                },
-                "salary_max_player":{
-                    "D":"Rafael Marquez",
-                    "GK":"Donovan Ricketts",
-                    "M":"Tim Cahill",
-                    "F":"Thierry Henry"
-                }
-            },
-            "2011":{
-                "salary_avg":{
-                    "D":115497,
-                    "GK":95816,
-                    "M":137005,
-                    "F":193935
-                },
-                "salary_max":{
-                    "D":4600000,
-                    "GK":545460,
-                    "M":5500000,
-                    "F":5000000
-                },
-                "salary_max_player":{
-                    "D":"Rafael Marquez",
-                    "GK":"Frank Rost",
-                    "M":"David Beckham",
-                    "F":"Thierry Henry"
-                }
-            },
-            "2010":{
-                "salary_avg":{
-                    "D":126678,
-                    "GK":85948,
-                    "M":155913,
-                    "F":207187
-                },
-                "salary_max":{
-                    "D":5544000,
-                    "GK":300000,
-                    "M":5500000,
-                    "F":5000000
-                },
-                "salary_max_player":{
-                    "D":"Rafael Marquez",
-                    "GK":"Kasey Keller",
-                    "M":"David Beckham",
-                    "F":"Thierry Henry"
-                }
-            },
-            "2017":{
-                "salary_avg":{
-                    "D":164165,
-                    "GK":146472,
-                    "M":347222,
-                    "F":444797
-                },
-                "salary_max":{
-                    "D":750000,
-                    "GK":2000000,
-                    "M":6660000,
-                    "F":5610000
-                },
-                "salary_max_player":{
-                    "D":"Jonathan Mensah",
-                    "GK":"Tim Howard",
-                    "M":" Kaka",
-                    "F":"David Villa"
-                }
-            },
-            "2008":{
-                "salary_avg":{
-                    "D":69087,
-                    "GK":55478,
-                    "M":139764,
-                    "F":123219
-                },
-                "salary_max":{
-                    "D":400000,
-                    "GK":213000,
-                    "M":5500000,
-                    "F":1500000
-                },
-                "salary_max_player":{
-                    "D":"Dulio Davino",
-                    "GK":"Joe Cannon",
-                    "M":"David Beckham",
-                    "F":"Juan Pablo Angel"
-                }
-            },
-            "2009":{
-                "salary_avg":{
-                    "D":75924,
-                    "GK":66822,
-                    "M":162359,
-                    "F":136575
-                },
-                "salary_max":{
-                    "D":255000,
-                    "GK":300000,
-                    "M":5500000,
-                    "F":1500000
-                },
-                "salary_max_player":{
-                    "D":"Pablo Mastroeni",
-                    "GK":"Kasey Keller",
-                    "M":"David Beckham",
-                    "F":"Juan Pablo Angel"
-                }
-            },
-            "2013":{
-                "salary_avg":{
-                    "D":107571,
-                    "GK":85781,
-                    "M":130985,
-                    "F":244541
-                },
-                "salary_max":{
-                    "D":331236,
-                    "GK":275000,
-                    "M":3500000,
-                    "F":4913004
-                },
-                "salary_max_player":{
-                    "D":"Heath Pearce",
-                    "GK":"Donovan Ricketts",
-                    "M":"Tim Cahill",
-                    "F":"Clint Dempsey"
-                }
-            },
-            "2014":{
-                "salary_avg":{
-                    "D":130434,
-                    "GK":92862,
-                    "M":220069,
-                    "F":308964
-                },
-                "salary_max":{
-                    "D":1200000,
-                    "GK":260000,
-                    "M":6660000,
-                    "F":6000000
-                },
-                "salary_max_player":{
-                    "D":"Liam Ridgewell",
-                    "GK":"Donovan Ricketts",
-                    "M":" Kaka",
-                    "F":"Jermain Defoe"
-                }
-            },
-            "2007":{
-                "salary_avg":{
-                    "D":68603,
-                    "GK":56502,
-                    "M":118814,
-                    "F":132739
-                },
-                "salary_max":{
-                    "D":280000,
-                    "GK":220800,
-                    "M":5500000,
-                    "F":2492316
-                },
-                "salary_max_player":{
-                    "D":"Pablo Mastroeni",
-                    "GK":"Shaka Hislop",
-                    "M":"David Beckham",
-                    "F":"Cuauhtemoc Blanco"
-                }
-            }
-        },
-        "teams":{
-            "2016":{
-                "CLB":{
-                    "salary_avg":{
-                        "D":229714,
-                        "GK":111499,
-                        "M":239568,
-                        "F":235000
-                    },
-                    "budget":5282748,
-                    "salary_max":1175000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Federico Higuain"
-                },
-                "NE":{
-                    "salary_avg":{
-                        "D":143000,
-                        "GK":91701,
-                        "M":228300,
-                        "F":256179
-                    },
-                    "budget":5564046,
-                    "salary_max":1000000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Kei Kamara"
-                },
-                "KC":{
-                    "salary_avg":{
-                        "D":184055,
-                        "GK":98583,
-                        "M":269649,
-                        "F":337850
-                    },
-                    "budget":6309194,
-                    "salary_max":800000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Roger Espinoza"
-                },
-                "SEA":{
-                    "salary_avg":{
-                        "D":148325,
-                        "GK":105002,
-                        "M":225519,
-                        "F":730252
-                    },
-                    "budget":9479113,
-                    "salary_max":3913008,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Clint Dempsey"
-                },
-                "ATL":{
-                    "salary_avg":{
-                        "GK":63000,
-                        "M":57006
-                    },
-                    "budget":177012,
-                    "salary_max":63000,
-                    "salary_max_position":"GK",
-                    "salary_max_player":"Alexander Tambakis"
-                },
-                "DC":{
-                    "salary_avg":{
-                        "D":125968,
-                        "GK":119694,
-                        "M":168078,
-                        "F":199586
-                    },
-                    "budget":4552163,
-                    "salary_max":420000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Alvaro Saborio"
-                },
-                "NYRB":{
-                    "salary_avg":{
-                        "D":155500,
-                        "GK":134248,
-                        "M":234150,
-                        "F":248750
-                    },
-                    "budget":5186746,
-                    "salary_max":650000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Bradley Wright-Phillips"
-                },
-                "PHI":{
-                    "salary_avg":{
-                        "D":100062,
-                        "GK":84666,
-                        "M":264200,
-                        "F":251250
-                    },
-                    "budget":5242500,
-                    "salary_max":725000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Maurice Edu"
-                },
-                "POR":{
-                    "salary_avg":{
-                        "D":203924,
-                        "GK":159353,
-                        "M":187458,
-                        "F":360500
-                    },
-                    "budget":6547661,
-                    "salary_max":1100000,
-                    "salary_max_position":"D",
-                    "salary_max_player":"Liam Ridgewell"
-                },
-                "MTL":{
-                    "salary_avg":{
-                        "D":193642,
-                        "GK":105066,
-                        "M":176303,
-                        "F":330457
-                    },
-                    "budget":5936300,
-                    "salary_max":1666667,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Didier Drogba"
-                },
-                "DAL":{
-                    "salary_avg":{
-                        "D":142000,
-                        "GK":88669,
-                        "M":154917,
-                        "F":95974
-                    },
-                    "budget":3746282,
-                    "salary_max":466000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Mauro Diaz"
-                },
-                "SJ":{
-                    "salary_avg":{
-                        "D":138361,
-                        "GK":92666,
-                        "M":186280,
-                        "F":325071
-                    },
-                    "budget":5821616,
-                    "salary_max":988000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Innocent Emeghara"
-                },
-                "NYCFC":{
-                    "salary_avg":{
-                        "D":136861,
-                        "GK":91669,
-                        "M":1291388,
-                        "F":1214605
-                    },
-                    "budget":20603922,
-                    "salary_max":6000000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Frank Lampard"
-                },
-                "CHI":{
-                    "salary_avg":{
-                        "D":131038,
-                        "GK":131250,
-                        "M":154458,
-                        "F":690000
-                    },
-                    "budget":5292596,
-                    "salary_max":1145000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Gilberto Junior"
-                },
-                "POOL":{
-                    "salary_avg":{
-                        "GK":62500
-                    },
-                    "budget":62500,
-                    "salary_max":62500,
-                    "salary_max_position":"GK",
-                    "salary_max_player":"Trey Mitchell"
-                },
-                "LA":{
-                    "salary_avg":{
-                        "D":189812,
-                        "GK":107500,
-                        "M":841111,
-                        "F":725950
-                    },
-                    "budget":16110500,
-                    "salary_max":6000000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Steven Gerrard"
-                },
-                "TOR":{
-                    "salary_avg":{
-                        "D":168305,
-                        "GK":74333,
-                        "M":886593,
-                        "F":1784025
-                    },
-                    "budget":19534650,
-                    "salary_max":6000000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Michael Bradley"
-                },
-                "ORL":{
-                    "salary_avg":{
-                        "D":173900,
-                        "GK":81333,
-                        "M":598066,
-                        "F":106100
-                    },
-                    "budget":10656500,
-                    "salary_max":6660000,
-                    "salary_max_position":"M",
-                    "salary_max_player":" Kaka"
-                },
-                "HOU":{
-                    "salary_avg":{
-                        "D":209324,
-                        "GK":105333,
-                        "M":180921,
-                        "F":372000
-                    },
-                    "budget":5312577,
-                    "salary_max":750000,
-                    "salary_max_position":"D",
-                    "salary_max_player":"DaMarcus Beasley"
-                },
-                "VAN":{
-                    "salary_avg":{
-                        "D":114000,
-                        "GK":161833,
-                        "M":224042,
-                        "F":286240
-                    },
-                    "budget":6012441,
-                    "salary_max":1232500,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Pedro Morales"
-                },
-                "RSL":{
-                    "salary_avg":{
-                        "D":128055,
-                        "GK":184333,
-                        "M":233687,
-                        "F":260714
-                    },
-                    "budget":5337500,
-                    "salary_max":1060000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Juan Manuel Martinez"
-                },
-                "COL":{
-                    "salary_avg":{
-                        "D":94309,
-                        "GK":588625,
-                        "M":260147,
-                        "F":270894
-                    },
-                    "budget":7715259,
-                    "salary_max":2100000,
-                    "salary_max_position":"GK",
-                    "salary_max_player":"Tim Howard"
-                }
-            },
-            "2015":{
-                "DAL":{
-                    "salary_avg":{
-                        "D":117500,
-                        "GK":141000,
-                        "M":131999,
-                        "F":164714
-                    },
-                    "budget":3669999,
-                    "salary_max":364000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Mauro Diaz"
-                },
-                "CLB":{
-                    "salary_avg":{
-                        "D":187744,
-                        "GK":96666,
-                        "M":200811,
-                        "F":291669
-                    },
-                    "budget":5296983,
-                    "salary_max":1175000,
-                    "salary_max_position":"M-F",
-                    "salary_max_player":"Federico Higuain"
-                },
-                "LA":{
-                    "salary_avg":{
-                        "D":255000,
-                        "GK":107500,
-                        "M":1121500,
-                        "F":660000
-                    },
-                    "budget":18965008,
-                    "salary_max":6200004,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Steven Gerrard"
-                },
-                "SJ":{
-                    "salary_avg":{
-                        "D":168500,
-                        "GK":80000,
-                        "M":168684,
-                        "F":192329
-                    },
-                    "budget":4821892,
-                    "salary_max":988000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Innocent Emeghara"
-                },
-                "NYCFC":{
-                    "salary_avg":{
-                        "D":136875,
-                        "GK":70554,
-                        "M":752365,
-                        "F":1458750
-                    },
-                    "budget":16922421,
-                    "salary_max":6000000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Frank Lampard"
-                },
-                "NE":{
-                    "salary_avg":{
-                        "D":148928,
-                        "GK":77751,
-                        "M":346045,
-                        "F":143156
-                    },
-                    "budget":5871005,
-                    "salary_max":2800000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Jermaine Jones"
-                },
-                "VAN":{
-                    "salary_avg":{
-                        "D":122900,
-                        "GK":142000,
-                        "M":208188,
-                        "F":176846
-                    },
-                    "budget":5526615,
-                    "salary_max":1190000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Pedro Morales"
-                },
-                "SEA":{
-                    "salary_avg":{
-                        "D":132579,
-                        "GK":115000,
-                        "M":181600,
-                        "F":976834
-                    },
-                    "budget":11434048,
-                    "salary_max":3913008,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Clint Dempsey"
-                },
-                "POOL":{
-                    "salary_avg":{
-                        "GK":50000
-                    },
-                    "budget":50000,
-                    "salary_max":50000,
-                    "salary_max_position":"GK",
-                    "salary_max_player":"Trey Mitchell"
-                },
-                "ORL":{
-                    "salary_avg":{
-                        "D":192619,
-                        "GK":108333,
-                        "M":552985,
-                        "F":102000
-                    },
-                    "budget":10388355,
-                    "salary_max":6660000,
-                    "salary_max_position":"M",
-                    "salary_max_player":" Kaka"
-                },
-                "COL":{
-                    "salary_avg":{
-                        "D":115943,
-                        "GK":91666,
-                        "M":148181,
-                        "F":262429
-                    },
-                    "budget":4655492,
-                    "salary_max":1125000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Kevin Doyle"
-                },
-                "DC":{
-                    "salary_avg":{
-                        "D":108833,
-                        "GK":156666,
-                        "M":149667,
-                        "F":226666
-                    },
-                    "budget":3791509,
-                    "salary_max":400000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Alvaro Saborio"
-                },
-                "POR":{
-                    "salary_avg":{
-                        "D":192000,
-                        "GK":130866,
-                        "M":160559,
-                        "F":307436
-                    },
-                    "budget":5748125,
-                    "salary_max":1000000,
-                    "salary_max_position":"D",
-                    "salary_max_player":"Liam Ridgewell"
-                },
-                "PHI":{
-                    "salary_avg":{
-                        "D":151377,
-                        "GK":68333,
-                        "M":204838,
-                        "F":165500
-                    },
-                    "budget":5057423,
-                    "salary_max":700000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Maurice Edu"
-                },
-                "MTL":{
-                    "salary_avg":{
-                        "D":152546,
-                        "GK":97333,
-                        "M":150990,
-                        "F":312708
-                    },
-                    "budget":5467536,
-                    "salary_max":1666668,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Didier Drogba"
-                },
-                "HOU":{
-                    "salary_avg":{
-                        "D":216109,
-                        "GK":85000,
-                        "M":143354,
-                        "F":166666
-                    },
-                    "budget":4632875,
-                    "salary_max":750000,
-                    "salary_max_position":"D",
-                    "salary_max_player":"DaMarcus Beasley"
-                },
-                "KC":{
-                    "salary_avg":{
-                        "D":160500,
-                        "GK":82500,
-                        "M":247692,
-                        "F":355875
-                    },
-                    "budget":5453500,
-                    "salary_max":750000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Roger Espinoza"
-                },
-                "TOR":{
-                    "salary_avg":{
-                        "D":154777,
-                        "GK":84000,
-                        "M":1245493,
-                        "F":815419
-                    },
-                    "budget":19761936,
-                    "salary_max":6000000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Michael Bradley"
-                },
-                "RSL":{
-                    "salary_avg":{
-                        "D":125555,
-                        "GK":156666,
-                        "M":168888,
-                        "F":198571
-                    },
-                    "budget":4598884,
-                    "salary_max":710000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Juan Manuel Martinez"
-                },
-                "CHI":{
-                    "salary_avg":{
-                        "D":111237,
-                        "GK":131666,
-                        "M":93735,
-                        "F":481784
-                    },
-                    "budget":5389775,
-                    "salary_max":1144992,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Gilberto Junior"
-                },
-                "NY":{
-                    "salary_avg":{
-                        "D":87876,
-                        "GK":92000,
-                        "M":143834,
-                        "F":203475
-                    },
-                    "budget":3753746,
-                    "salary_max":600000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Bradley Wright-Phillips"
-                }
-            },
-            "2012":{
-                "CLB":{
-                    "salary_avg":{
-                        "D":123123,
-                        "GK":97000,
-                        "M":103295,
-                        "F":112683
-                    },
-                    "budget":3111134,
-                    "salary_max":310000,
-                    "salary_max_position":"D",
-                    "salary_max_player":"Chad Marshall"
-                },
-                "NE":{
-                    "salary_avg":{
-                        "D":73607,
-                        "GK":81733,
-                        "M":114282,
-                        "F":77487
-                    },
-                    "budget":2284905,
-                    "salary_max":400000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Benny Feilhaber"
-                },
-                "LA":{
-                    "salary_avg":{
-                        "D":107343,
-                        "GK":61431,
-                        "M":349965,
-                        "F":628312
-                    },
-                    "budget":10825821,
-                    "salary_max":3000000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"David Beckham"
-                },
-                "SJ":{
-                    "salary_avg":{
-                        "D":92300,
-                        "GK":86586,
-                        "M":100970,
-                        "F":91551
-                    },
-                    "budget":2878166,
-                    "salary_max":300000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Chris Wondolowski"
-                },
-                "TFC":{
-                    "salary_avg":{
-                        "D":330000,
-                        "GK":44004
-                    },
-                    "budget":374004,
-                    "salary_max":330000,
-                    "salary_max_position":"D",
-                    "salary_max_player":"Darren O'Dea"
-                },
-                "KC":{
-                    "salary_avg":{
-                        "D":104695,
-                        "GK":105450,
-                        "M":91818,
-                        "F":95000
-                    },
-                    "budget":2893657,
-                    "salary_max":252000,
-                    "salary_max_position":"D",
-                    "salary_max_player":"Julio Cesar"
-                },
-                "SEA":{
-                    "salary_avg":{
-                        "D":101493,
-                        "GK":77949,
-                        "M":138262,
-                        "F":138025
-                    },
-                    "budget":3789781,
-                    "salary_max":600000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Fredy Montero"
-                },
-                "POOL":{
-                    "salary_avg":{
-                        "GK":37202
-                    },
-                    "budget":111606,
-                    "salary_max":44100,
-                    "salary_max_position":"GK",
-                    "salary_max_player":"Chris Sharpe"
-                },
-                "COL":{
-                    "salary_avg":{
-                        "D":125116,
-                        "GK":88880,
-                        "M":94799,
-                        "F":164799
-                    },
-                    "budget":3111123,
-                    "salary_max":400000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Conor Casey"
-                },
-                "DC":{
-                    "salary_avg":{
-                        "D":108231,
-                        "GK":52701,
-                        "M":140066,
-                        "F":145837
-                    },
-                    "budget":3453679,
-                    "salary_max":617857,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Dwayne DeRosario"
-                },
-                "POR":{
-                    "salary_avg":{
-                        "D":81143,
-                        "GK":118833,
-                        "M":71593,
-                        "F":211386
-                    },
-                    "budget":3776116,
-                    "salary_max":1250000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Kris Boyd"
-                },
-                "DAL":{
-                    "salary_avg":{
-                        "D":93247,
-                        "GK":94666,
-                        "M":299861,
-                        "F":164157
-                    },
-                    "budget":4865549,
-                    "salary_max":1863996,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Julian de Guzman"
-                },
-                "PHI":{
-                    "salary_avg":{
-                        "D":143350,
-                        "GK":59333,
-                        "M":113375,
-                        "F":63166
-                    },
-                    "budget":2861006,
-                    "salary_max":400000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Freddy Adu"
-                },
-                "MTL":{
-                    "salary_avg":{
-                        "D":90575,
-                        "GK":99666,
-                        "M":93667,
-                        "F":225747
-                    },
-                    "budget":3453853,
-                    "salary_max":1000008,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Marco Di Vaio"
-                },
-                "HOU":{
-                    "salary_avg":{
-                        "D":105604,
-                        "GK":65950,
-                        "M":116767,
-                        "F":108247
-                    },
-                    "budget":2901166,
-                    "salary_max":265000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Brad Davis"
-                },
-                "VAN":{
-                    "salary_avg":{
-                        "D":141231,
-                        "GK":85000,
-                        "M":129409,
-                        "F":257914
-                    },
-                    "budget":4551665,
-                    "salary_max":1221816,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Kenny Miller"
-                },
-                "TOR":{
-                    "salary_avg":{
-                        "D":81825,
-                        "GK":65950,
-                        "M":293423,
-                        "F":280314
-                    },
-                    "budget":5455463,
-                    "salary_max":2000000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Torsten Frings"
-                },
-                "RSL":{
-                    "salary_avg":{
-                        "D":127067,
-                        "GK":89916,
-                        "M":121113,
-                        "F":137642
-                    },
-                    "budget":3206785,
-                    "salary_max":425000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Javier Morales"
-                },
-                "CHI":{
-                    "salary_avg":{
-                        "D":105328,
-                        "GK":67333,
-                        "M":111233,
-                        "F":151859
-                    },
-                    "budget":3600214,
-                    "salary_max":360000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Sherjill MacDonald"
-                },
-                "NY":{
-                    "salary_avg":{
-                        "D":608222,
-                        "GK":45437,
-                        "M":465486,
-                        "F":924625
-                    },
-                    "budget":15814368,
-                    "salary_max":5000000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Thierry Henry"
-                },
-                "CHV":{
-                    "salary_avg":{
-                        "D":109083,
-                        "GK":84250,
-                        "M":113066,
-                        "F":117416
-                    },
-                    "budget":3047728,
-                    "salary_max":495000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Shalrie Joseph"
-                }
-            },
-            "2011":{
-                "CLB":{
-                    "salary_avg":{
-                        "D":81666,
-                        "GK":83366,
-                        "M":89433,
-                        "F":154829
-                    },
-                    "budget":3004123,
-                    "salary_max":500000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Andres Mendoza"
-                },
-                "NE":{
-                    "salary_avg":{
-                        "D":68500,
-                        "GK":90437,
-                        "M":138410,
-                        "F":87098
-                    },
-                    "budget":2698503,
-                    "salary_max":475000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Shalrie Joseph"
-                },
-                "SJ":{
-                    "salary_avg":{
-                        "D":73443,
-                        "GK":90001,
-                        "M":108722,
-                        "F":78172
-                    },
-                    "budget":2600712,
-                    "salary_max":313500,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Bobby Convey"
-                },
-                "TFC":{
-                    "salary_avg":{
-                        "D":71191,
-                        "GK":71000,
-                        "M":254958,
-                        "F":196009
-                    },
-                    "budget":5440626,
-                    "salary_max":1863996,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Julian de Guzman"
-                },
-                "VAN":{
-                    "salary_avg":{
-                        "D":91547,
-                        "GK":99033,
-                        "M":107421,
-                        "F":209685
-                    },
-                    "budget":3566997,
-                    "salary_max":660000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Eric Hassli"
-                },
-                "SEA":{
-                    "salary_avg":{
-                        "D":89395,
-                        "GK":108201,
-                        "M":84320,
-                        "F":108382
-                    },
-                    "budget":3033191,
-                    "salary_max":500000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Fredy Montero"
-                },
-                "POOL":{
-                    "salary_avg":{
-                        "GK":42000
-                    },
-                    "budget":126000,
-                    "salary_max":42000,
-                    "salary_max_position":"GK",
-                    "salary_max_player":"Kevin Guppy"
-                },
-                "LA":{
-                    "salary_avg":{
-                        "D":78744,
-                        "GK":101490,
-                        "M":608195,
-                        "F":716886
-                    },
-                    "budget":12830222,
-                    "salary_max":5500000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"David Beckham"
-                },
-                "DC":{
-                    "salary_avg":{
-                        "D":73094,
-                        "GK":56333,
-                        "M":138108,
-                        "F":129660
-                    },
-                    "budget":2958886,
-                    "salary_max":425000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Dwayne DeRosario"
-                },
-                "POR":{
-                    "salary_avg":{
-                        "D":77075,
-                        "GK":121333,
-                        "M":64538,
-                        "F":84400
-                    },
-                    "budget":2299670,
-                    "salary_max":250000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Kenny Cooper"
-                },
-                "TOR":{
-                    "salary_avg":{
-                        "D":68596,
-                        "M":55000
-                    },
-                    "budget":123596,
-                    "salary_max":68596,
-                    "salary_max_position":"D",
-                    "salary_max_player":"Andy Iro"
-                },
-                "DAL":{
-                    "salary_avg":{
-                        "D":87400,
-                        "GK":96900,
-                        "M":122687,
-                        "F":141429
-                    },
-                    "budget":2863854,
-                    "salary_max":600000,
-                    "salary_max_position":"M-F",
-                    "salary_max_player":"David Ferreira"
-                },
-                "PHI":{
-                    "salary_avg":{
-                        "D":165250,
-                        "GK":155000,
-                        "M":123191,
-                        "F":64743
-                    },
-                    "budget":2870942,
-                    "salary_max":475884,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Freddy Adu"
-                },
-                "HOU":{
-                    "salary_avg":{
-                        "D":122916,
-                        "GK":53200,
-                        "M":102546,
-                        "F":172343
-                    },
-                    "budget":3059176,
-                    "salary_max":375000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Brian Ching"
-                },
-                "KC":{
-                    "salary_avg":{
-                        "D":85735,
-                        "GK":101500,
-                        "M":87139,
-                        "F":136450
-                    },
-                    "budget":3109530,
-                    "salary_max":429996,
-                    "salary_max_position":"F",
-                    "salary_max_player":" Jeferson"
-                },
-                "CHI":{
-                    "salary_avg":{
-                        "D":77178,
-                        "GK":59200,
-                        "M":93226,
-                        "F":91514
-                    },
-                    "budget":2538304,
-                    "salary_max":240000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Cristian Nazarit"
-                },
-                "RSL":{
-                    "salary_avg":{
-                        "D":103262,
-                        "GK":80666,
-                        "M":137443,
-                        "F":101159
-                    },
-                    "budget":2946031,
-                    "salary_max":400000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Javier Morales"
-                },
-                "COL":{
-                    "salary_avg":{
-                        "D":99505,
-                        "GK":89083,
-                        "M":85461,
-                        "F":148406
-                    },
-                    "budget":2991458,
-                    "salary_max":400000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Conor Casey"
-                },
-                "NY":{
-                    "salary_avg":{
-                        "D":559545,
-                        "GK":207978,
-                        "M":107601,
-                        "F":795571
-                    },
-                    "budget":12583039,
-                    "salary_max":5000000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Thierry Henry"
-                },
-                "CHV":{
-                    "salary_avg":{
-                        "D":114304,
-                        "GK":87498,
-                        "M":75571,
-                        "F":174067
-                    },
-                    "budget":3346214,
-                    "salary_max":1000000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Juan Pablo Angel"
-                }
-            },
-            "2010":{
-                "DAL":{
-                    "salary_avg":{
-                        "D":79838,
-                        "GK":103333,
-                        "M":87935,
-                        "F":112246
-                    },
-                    "budget":2517610,
-                    "salary_max":300000,
-                    "salary_max_position":"M-F",
-                    "salary_max_player":"David Ferreira"
-                },
-                "NE":{
-                    "salary_avg":{
-                        "D":63041,
-                        "GK":83002,
-                        "M":101364,
-                        "F":133944
-                    },
-                    "budget":2795765,
-                    "salary_max":450000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Shalrie Joseph"
-                },
-                "SJ":{
-                    "salary_avg":{
-                        "D":68714,
-                        "GK":137000,
-                        "M":103944,
-                        "F":113584
-                    },
-                    "budget":2273338,
-                    "salary_max":285000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Bobby Convey"
-                },
-                "Pool":{
-                    "salary_avg":{
-                        "GK":40000
-                    },
-                    "budget":120000,
-                    "salary_max":40000,
-                    "salary_max_position":"GK",
-                    "salary_max_player":"Kevin Guppy"
-                },
-                "CLB":{
-                    "salary_avg":{
-                        "D":99622,
-                        "GK":82500,
-                        "M":107155,
-                        "F":126367
-                    },
-                    "budget":2372912,
-                    "salary_max":250000,
-                    "salary_max_position":"D",
-                    "salary_max_player":"Chad Marshall"
-                },
-                "None":{
-                    "salary_avg":{
-                        "D":102355,
-                        "F":88000
-                    },
-                    "budget":292710,
-                    "salary_max":120000,
-                    "salary_max_position":"D",
-                    "salary_max_player":"Kevin Goldthwaite"
-                },
-                "KC":{
-                    "salary_avg":{
-                        "D":90186,
-                        "GK":78000,
-                        "M":94151,
-                        "F":128287
-                    },
-                    "budget":2583878,
-                    "salary_max":232750,
-                    "salary_max_position":"D",
-                    "salary_max_player":"Jimmy Conrad"
-                },
-                "SEA":{
-                    "salary_avg":{
-                        "D":81958,
-                        "GK":170000,
-                        "M":95703,
-                        "F":125600
-                    },
-                    "budget":2980515,
-                    "salary_max":480000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Blaise Nkufo"
-                },
-                "LA":{
-                    "salary_avg":{
-                        "D":84829,
-                        "GK":89908,
-                        "M":867214,
-                        "F":370135
-                    },
-                    "budget":9609808,
-                    "salary_max":5500000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"David Beckham"
-                },
-                "DC":{
-                    "salary_avg":{
-                        "D":66539,
-                        "GK":93336,
-                        "M":105400,
-                        "F":113000
-                    },
-                    "budget":2540939,
-                    "salary_max":380000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Branko Boskovic"
-                },
-                "PHI":{
-                    "salary_avg":{
-                        "D":122500,
-                        "GK":70000,
-                        "M":99834,
-                        "F":136812
-                    },
-                    "budget":2370262,
-                    "salary_max":250000,
-                    "salary_max_position":"D",
-                    "salary_max_player":"Daniel Califf"
-                },
-                "HOU":{
-                    "salary_avg":{
-                        "D":126200,
-                        "GK":88000,
-                        "M":84875,
-                        "F":136750
-                    },
-                    "budget":2388500,
-                    "salary_max":350000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Brian Ching"
-                },
-                "CHI":{
-                    "salary_avg":{
-                        "D":75217,
-                        "GK":47500,
-                        "M":416875,
-                        "F":309893
-                    },
-                    "budget":4836214,
-                    "salary_max":1400004,
-                    "salary_max_position":"M-F",
-                    "salary_max_player":"Nery Castillo"
-                },
-                "TFC":{
-                    "salary_avg":{
-                        "D":71659,
-                        "GK":60000,
-                        "M":333256,
-                        "F":266122
-                    },
-                    "budget":4786124,
-                    "salary_max":1670796,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Julian de Guzman"
-                },
-                "RSL":{
-                    "salary_avg":{
-                        "D":99875,
-                        "GK":66666,
-                        "M":103770,
-                        "F":72330
-                    },
-                    "budget":2346344,
-                    "salary_max":250000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Kyle Beckerman"
-                },
-                "COL":{
-                    "salary_avg":{
-                        "D":103770,
-                        "GK":76333,
-                        "M":95372,
-                        "F":110250
-                    },
-                    "budget":2434050,
-                    "salary_max":350000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Conor Casey"
-                },
-                "NY":{
-                    "salary_avg":{
-                        "D":849893,
-                        "GK":113500,
-                        "M":95761,
-                        "F":903000
-                    },
-                    "budget":14470151,
-                    "salary_max":5544000,
-                    "salary_max_position":"D",
-                    "salary_max_player":"Rafael Marquez"
-                },
-                "CHV":{
-                    "salary_avg":{
-                        "D":87285,
-                        "GK":99998,
-                        "M":83966,
-                        "F":87653
-                    },
-                    "budget":2389825,
-                    "salary_max":216000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Rodolfo Espinoza"
-                }
-            },
-            "2017":{
-                "CLB":{
-                    "salary_avg":{
-                        "D":251550,
-                        "GK":79336,
-                        "M":213158,
-                        "F":186593
-                    },
-                    "budget":6345232,
-                    "salary_max":1050000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Federico Higuain"
-                },
-                "NE":{
-                    "salary_avg":{
-                        "D":227844,
-                        "GK":77492,
-                        "M":227177,
-                        "F":279220
-                    },
-                    "budget":5406993,
-                    "salary_max":840000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Xavier Kouassi"
-                },
-                "KC":{
-                    "salary_avg":{
-                        "D":164782,
-                        "GK":99334,
-                        "M":468286,
-                        "F":200377
-                    },
-                    "budget":6223848,
-                    "salary_max":850000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Roger Espinoza"
-                },
-                "SEA":{
-                    "salary_avg":{
-                        "D":174837,
-                        "GK":127261,
-                        "M":313017,
-                        "F":773725
-                    },
-                    "budget":8986700,
-                    "salary_max":3200000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Clint Dempsey"
-                },
-                "ATL":{
-                    "salary_avg":{
-                        "D":148514,
-                        "GK":69004,
-                        "M":356332,
-                        "F":291700
-                    },
-                    "budget":8035616,
-                    "salary_max":1912500,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Miguel Almiron"
-                },
-                "DC":{
-                    "salary_avg":{
-                        "D":165416,
-                        "GK":156209,
-                        "M":193803,
-                        "F":196475
-                    },
-                    "budget":4812135,
-                    "salary_max":500000,
-                    "salary_max_position":"M-F",
-                    "salary_max_player":"Luciano Acosta"
-                },
-                "NYRB":{
-                    "salary_avg":{
-                        "D":141899,
-                        "GK":195004,
-                        "M":218546,
-                        "F":391839
-                    },
-                    "budget":6313982,
-                    "salary_max":1500000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Bradley Wright-Phillips"
-                },
-                "PHI":{
-                    "salary_avg":{
-                        "D":97115,
-                        "GK":96001,
-                        "M":320895,
-                        "F":249826
-                    },
-                    "budget":6516875,
-                    "salary_max":1131000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Alejandro Bedoya"
-                },
-                "POR":{
-                    "salary_avg":{
-                        "D":164351,
-                        "GK":87666,
-                        "M":458456,
-                        "F":403501
-                    },
-                    "budget":9294532,
-                    "salary_max":2227500,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Diego Valeri"
-                },
-                "MTL":{
-                    "salary_avg":{
-                        "D":209125,
-                        "GK":103916,
-                        "M":173651,
-                        "F":243045
-                    },
-                    "budget":5074669,
-                    "salary_max":700000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Matteo Mancosu"
-                },
-                "LAFC":{
-                    "salary_avg":{
-                        "M":59004
-                    },
-                    "budget":118008,
-                    "salary_max":65004,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Carlos Alvarez"
-                },
-                "DAL":{
-                    "salary_avg":{
-                        "D":185286,
-                        "GK":119000,
-                        "M":245821,
-                        "F":138875
-                    },
-                    "budget":5990579,
-                    "salary_max":784000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Mauro Diaz"
-                },
-                "SJ":{
-                    "salary_avg":{
-                        "D":184431,
-                        "GK":111668,
-                        "M":232936,
-                        "F":318252
-                    },
-                    "budget":6429566,
-                    "salary_max":800000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Simon Dawkins"
-                },
-                "NYCFC":{
-                    "salary_avg":{
-                        "D":157208,
-                        "GK":117088,
-                        "M":805352,
-                        "F":1458987
-                    },
-                    "budget":17370523,
-                    "salary_max":5610000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"David Villa"
-                },
-                "MNUFC":{
-                    "salary_avg":{
-                        "D":162902,
-                        "GK":129500,
-                        "M":221168,
-                        "F":125000
-                    },
-                    "budget":4926046,
-                    "salary_max":550008,
-                    "salary_max_position":"D",
-                    "salary_max_player":"Vadim Demidov"
-                },
-                "CHI":{
-                    "salary_avg":{
-                        "D":163286,
-                        "GK":123001,
-                        "M":591401,
-                        "F":676199
-                    },
-                    "budget":12272623,
-                    "salary_max":5400000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Bastian Schweinsteiger"
-                },
-                "LA":{
-                    "salary_avg":{
-                        "D":186308,
-                        "GK":83543,
-                        "M":394363,
-                        "F":569330
-                    },
-                    "budget":9833666,
-                    "salary_max":3750000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Giovani Dos Santos"
-                },
-                "ORL":{
-                    "salary_avg":{
-                        "D":173267,
-                        "GK":108250,
-                        "M":751125,
-                        "F":218293
-                    },
-                    "budget":12382053,
-                    "salary_max":6660000,
-                    "salary_max_position":"M",
-                    "salary_max_player":" Kaka"
-                },
-                "HOU":{
-                    "salary_avg":{
-                        "D":140881,
-                        "GK":118770,
-                        "M":158517,
-                        "F":310750
-                    },
-                    "budget":4904049,
-                    "salary_max":650000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Erick Torres"
-                },
-                "VAN":{
-                    "salary_avg":{
-                        "D":175910,
-                        "GK":168334,
-                        "M":219084,
-                        "F":430000
-                    },
-                    "budget":7040366,
-                    "salary_max":1400000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Fredy Montero"
-                },
-                "TOR":{
-                    "salary_avg":{
-                        "D":146763,
-                        "GK":111669,
-                        "M":832641,
-                        "F":1805256
-                    },
-                    "budget":20074946,
-                    "salary_max":6000000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Michael Bradley"
-                },
-                "RSL":{
-                    "salary_avg":{
-                        "D":138057,
-                        "GK":204050,
-                        "M":286014,
-                        "F":375377
-                    },
-                    "budget":6856440,
-                    "salary_max":1750000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Yura Movsisyan"
-                },
-                "COL":{
-                    "salary_avg":{
-                        "D":87553,
-                        "GK":738716,
-                        "M":137783,
-                        "F":584000
-                    },
-                    "budget":7254748,
-                    "salary_max":2000000,
-                    "salary_max_position":"GK",
-                    "salary_max_player":"Tim Howard"
-                }
-            },
-            "2008":{
-                "DAL":{
-                    "salary_avg":{
-                        "D":98911,
-                        "GK":69333,
-                        "M":65012,
-                        "F":81740
-                    },
-                    "budget":2287050,
-                    "salary_max":400000,
-                    "salary_max_position":"D",
-                    "salary_max_player":"Dulio Davino"
-                },
-                "NE":{
-                    "salary_avg":{
-                        "D":76453,
-                        "GK":77150,
-                        "M":69255,
-                        "F":102177
-                    },
-                    "budget":2090045,
-                    "salary_max":325008,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Taylor Twellman"
-                },
-                "SJ":{
-                    "salary_avg":{
-                        "D":62951,
-                        "GK":112950,
-                        "M":101129,
-                        "F":90466
-                    },
-                    "budget":2401587,
-                    "salary_max":330000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Darren Huckerby"
-                },
-                "Pool":{
-                    "salary_avg":{
-                        "GK":22860,
-                        "F":12900
-                    },
-                    "budget":127200,
-                    "salary_max":33000,
-                    "salary_max_position":"GK",
-                    "salary_max_player":"David Monsalve"
-                },
-                "CLB":{
-                    "salary_avg":{
-                        "D":69984,
-                        "GK":40233,
-                        "M":61210,
-                        "F":81941
-                    },
-                    "budget":2088180,
-                    "salary_max":250000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Guillermo Barros Schelotto"
-                },
-                "CHI":{
-                    "salary_avg":{
-                        "D":66142,
-                        "GK":36866,
-                        "M":369830,
-                        "F":93124
-                    },
-                    "budget":4382546,
-                    "salary_max":2492316,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Cuauhtemoc Blanco"
-                },
-                "SEA":{
-                    "salary_avg":{
-                        "M":58500
-                    },
-                    "budget":117000,
-                    "salary_max":84000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Sebastian Le Toux"
-                },
-                "LA":{
-                    "salary_avg":{
-                        "D":64745,
-                        "GK":39725,
-                        "M":662577,
-                        "F":176472
-                    },
-                    "budget":8069604,
-                    "salary_max":5500000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"David Beckham"
-                },
-                "DC":{
-                    "salary_avg":{
-                        "D":59200,
-                        "GK":77940,
-                        "M":183826,
-                        "F":265250
-                    },
-                    "budget":4335770,
-                    "salary_max":1500000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Marcelo Gallardo"
-                },
-                "TFC":{
-                    "salary_avg":{
-                        "D":73355,
-                        "GK":93000,
-                        "M":113214,
-                        "F":102310
-                    },
-                    "budget":2354874,
-                    "salary_max":350000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Carlos Ruiz"
-                },
-                "HOU":{
-                    "salary_avg":{
-                        "D":78499,
-                        "GK":79498,
-                        "M":85458,
-                        "F":96150
-                    },
-                    "budget":2386656,
-                    "salary_max":324999,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Dwayne DeRosario"
-                },
-                "KC":{
-                    "salary_avg":{
-                        "D":55316,
-                        "GK":65300,
-                        "M":58200,
-                        "F":219325
-                    },
-                    "budget":2314178,
-                    "salary_max":720000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Claudio Lopez"
-                },
-                "RSL":{
-                    "salary_avg":{
-                        "D":73837,
-                        "GK":59733,
-                        "M":94528,
-                        "F":60229
-                    },
-                    "budget":2171090,
-                    "salary_max":240000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Javier Morales"
-                },
-                "COL":{
-                    "salary_avg":{
-                        "D":62042,
-                        "GK":33672,
-                        "M":97075,
-                        "F":108102
-                    },
-                    "budget":2318744,
-                    "salary_max":385000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Christian Gomez"
-                },
-                "NY":{
-                    "salary_avg":{
-                        "D":60034,
-                        "GK":43450,
-                        "M":64500,
-                        "F":293740
-                    },
-                    "budget":3190516,
-                    "salary_max":1500000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Juan Pablo Angel"
-                },
-                "CHV":{
-                    "salary_avg":{
-                        "D":71219,
-                        "GK":46218,
-                        "M":87924,
-                        "F":65483
-                    },
-                    "budget":2294448,
-                    "salary_max":255000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Ante Razov"
-                }
-            },
-            "2009":{
-                "DAL":{
-                    "salary_avg":{
-                        "D":61754,
-                        "GK":81550,
-                        "M":102989,
-                        "F":156717
-                    },
-                    "budget":2346619,
-                    "salary_max":300000,
-                    "salary_max_position":"M-F",
-                    "salary_max_player":"David Ferreira"
-                },
-                "NE":{
-                    "salary_avg":{
-                        "D":84626,
-                        "GK":75814,
-                        "M":91931,
-                        "F":148325
-                    },
-                    "budget":2587003,
-                    "salary_max":425000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Shalrie Joseph"
-                },
-                "SJ":{
-                    "salary_avg":{
-                        "D":51866,
-                        "GK":79366,
-                        "M":89767,
-                        "F":160442
-                    },
-                    "budget":2003760,
-                    "salary_max":360000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Darren Huckerby"
-                },
-                "Pool":{
-                    "salary_avg":{
-                        "GK":31220
-                    },
-                    "budget":156100,
-                    "salary_max":34000,
-                    "salary_max_position":"GK",
-                    "salary_max_player":"Miguel Benitez"
-                },
-                "CLB":{
-                    "salary_avg":{
-                        "D":100191,
-                        "GK":48550,
-                        "M":142547,
-                        "F":157373
-                    },
-                    "budget":2573342,
-                    "salary_max":650000,
-                    "salary_max_position":"F-M",
-                    "salary_max_player":"Guillermo Barros Schelotto"
-                },
-                "KC":{
-                    "salary_avg":{
-                        "D":70785,
-                        "GK":73250,
-                        "M":65875,
-                        "F":95056
-                    },
-                    "budget":2084923,
-                    "salary_max":220000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Davy Arnaud"
-                },
-                "SEA":{
-                    "salary_avg":{
-                        "D":59139,
-                        "GK":127166,
-                        "M":185745,
-                        "F":112501
-                    },
-                    "budget":3221212,
-                    "salary_max":1300000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Fredrik Ljungberg"
-                },
-                "LA":{
-                    "salary_avg":{
-                        "D":77142,
-                        "GK":95670,
-                        "M":994017,
-                        "F":178283
-                    },
-                    "budget":8531425,
-                    "salary_max":5500000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"David Beckham"
-                },
-                "DC":{
-                    "salary_avg":{
-                        "D":57400,
-                        "GK":27400,
-                        "M":86363,
-                        "F":170672
-                    },
-                    "budget":2981654,
-                    "salary_max":720000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Luciano Emilio"
-                },
-                "TFC":{
-                    "salary_avg":{
-                        "D":78986,
-                        "GK":52300,
-                        "M":315814,
-                        "F":143166
-                    },
-                    "budget":3577074,
-                    "salary_max":909600,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Julian de Guzman"
-                },
-                "HOU":{
-                    "salary_avg":{
-                        "D":117636,
-                        "GK":82250,
-                        "M":92985,
-                        "F":86754
-                    },
-                    "budget":2489703,
-                    "salary_max":248050,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Ricardo Clark"
-                },
-                "CHI":{
-                    "salary_avg":{
-                        "D":61027,
-                        "GK":84500,
-                        "M":473477,
-                        "F":108011
-                    },
-                    "budget":4721583,
-                    "salary_max":2769240,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Cuauhtemoc Blanco"
-                },
-                "RSL":{
-                    "salary_avg":{
-                        "D":87740,
-                        "GK":71333,
-                        "M":85084,
-                        "F":58729
-                    },
-                    "budget":1945371,
-                    "salary_max":160650,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Kyle Beckerman"
-                },
-                "COL":{
-                    "salary_avg":{
-                        "D":90420,
-                        "GK":67657,
-                        "M":110607,
-                        "F":100351
-                    },
-                    "budget":2228536,
-                    "salary_max":255000,
-                    "salary_max_position":"M-D",
-                    "salary_max_player":"Pablo Mastroeni"
-                },
-                "NY":{
-                    "salary_avg":{
-                        "D":66075,
-                        "GK":78999,
-                        "M":66285,
-                        "F":359020
-                    },
-                    "budget":3097599,
-                    "salary_max":1500000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Juan Pablo Angel"
-                },
-                "CHV":{
-                    "salary_avg":{
-                        "D":92462,
-                        "GK":39650,
-                        "M":88658,
-                        "F":71117
-                    },
-                    "budget":2353283,
-                    "salary_max":170000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Sacha Kljestan"
-                }
-            },
-            "2013":{
-                "DAL":{
-                    "salary_avg":{
-                        "D":98529,
-                        "GK":71350,
-                        "M":140989,
-                        "F":232700
-                    },
-                    "budget":4076343,
-                    "salary_max":625000,
-                    "salary_max_position":"M-F",
-                    "salary_max_player":"David Ferreira"
-                },
-                "NE":{
-                    "salary_avg":{
-                        "D":78189,
-                        "GK":93376,
-                        "M":93723,
-                        "F":113839
-                    },
-                    "budget":2742432,
-                    "salary_max":275000,
-                    "salary_max_position":"M-F",
-                    "salary_max_player":"Juan Toja"
-                },
-                "SJ":{
-                    "salary_avg":{
-                        "D":110453,
-                        "GK":96533,
-                        "M":135229,
-                        "F":94232
-                    },
-                    "budget":3558741,
-                    "salary_max":550000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Chris Wondolowski"
-                },
-                "CLB":{
-                    "salary_avg":{
-                        "D":118340,
-                        "GK":57948,
-                        "M":125102,
-                        "F":128963
-                    },
-                    "budget":3169668,
-                    "salary_max":440000,
-                    "salary_max_position":"M-F",
-                    "salary_max_player":"Federico Higuain"
-                },
-                "RSL":{
-                    "salary_avg":{
-                        "D":98252,
-                        "GK":92906,
-                        "M":125895,
-                        "F":119321
-                    },
-                    "budget":3503642,
-                    "salary_max":360000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Alvaro Saborio"
-                },
-                "CHI":{
-                    "salary_avg":{
-                        "D":121599,
-                        "GK":67208,
-                        "M":170354,
-                        "F":124650
-                    },
-                    "budget":4465170,
-                    "salary_max":768000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Egidio Rios"
-                },
-                "SEA":{
-                    "salary_avg":{
-                        "D":100640,
-                        "GK":105500,
-                        "M":92405,
-                        "F":868202
-                    },
-                    "budget":9767100,
-                    "salary_max":4913004,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Clint Dempsey"
-                },
-                "POOL":{
-                    "salary_avg":{
-                        "GK":35125
-                    },
-                    "budget":70250,
-                    "salary_max":35125,
-                    "salary_max_position":"GK",
-                    "salary_max_player":"Doug Herrick"
-                },
-                "LA":{
-                    "salary_avg":{
-                        "D":110905,
-                        "GK":82375,
-                        "M":99475,
-                        "F":865390
-                    },
-                    "budget":9206430,
-                    "salary_max":4000000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Robbie Keane"
-                },
-                "DC":{
-                    "salary_avg":{
-                        "D":107748,
-                        "GK":56000,
-                        "M":140927,
-                        "F":122212
-                    },
-                    "budget":3232138,
-                    "salary_max":600000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Dwayne DeRosario"
-                },
-                "POR":{
-                    "salary_avg":{
-                        "D":90752,
-                        "GK":128204,
-                        "M":130246,
-                        "F":119332
-                    },
-                    "budget":3466000,
-                    "salary_max":400000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Diego Valeri"
-                },
-                "PHI":{
-                    "salary_avg":{
-                        "D":145100,
-                        "GK":78250,
-                        "M":116182,
-                        "F":83146
-                    },
-                    "budget":3322942,
-                    "salary_max":495000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Jose Kleberson"
-                },
-                "MTL":{
-                    "salary_avg":{
-                        "D":130180,
-                        "GK":102208,
-                        "M":105003,
-                        "F":227572
-                    },
-                    "budget":4263316,
-                    "salary_max":1000008,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Marco Di Vaio"
-                },
-                "HOU":{
-                    "salary_avg":{
-                        "D":113604,
-                        "GK":103833,
-                        "M":135987,
-                        "F":103979
-                    },
-                    "budget":3184833,
-                    "salary_max":325000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Brad Davis"
-                },
-                "VAN":{
-                    "salary_avg":{
-                        "D":135391,
-                        "GK":107906,
-                        "M":105611,
-                        "F":198885
-                    },
-                    "budget":4279508,
-                    "salary_max":1114992,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Kenny Miller"
-                },
-                "KC":{
-                    "salary_avg":{
-                        "D":82916,
-                        "GK":112278,
-                        "M":126520,
-                        "F":135214
-                    },
-                    "budget":3205085,
-                    "salary_max":350000,
-                    "salary_max_position":"F-M",
-                    "salary_max_player":"Graham Zusi"
-                },
-                "TOR":{
-                    "salary_avg":{
-                        "D":87249,
-                        "GK":71125,
-                        "M":94171,
-                        "F":234321
-                    },
-                    "budget":3610447,
-                    "salary_max":1250000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Danny Koevermans"
-                },
-                "COL":{
-                    "salary_avg":{
-                        "D":89836,
-                        "GK":95041,
-                        "M":83701,
-                        "F":173833
-                    },
-                    "budget":3066900,
-                    "salary_max":275000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Edson Buddle"
-                },
-                "NY":{
-                    "salary_avg":{
-                        "D":149654,
-                        "GK":55406,
-                        "M":395168,
-                        "F":608959
-                    },
-                    "budget":9981937,
-                    "salary_max":3750000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Thierry Henry"
-                },
-                "CHV":{
-                    "salary_avg":{
-                        "D":107384,
-                        "GK":99666,
-                        "M":69407,
-                        "F":73894
-                    },
-                    "budget":2409807,
-                    "salary_max":228000,
-                    "salary_max_position":"D",
-                    "salary_max_player":"Carlos Bocanegra"
-                }
-            },
-            "2014":{
-                "CLB":{
-                    "salary_avg":{
-                        "D":126732,
-                        "GK":77441,
-                        "M":115665,
-                        "F":140532
-                    },
-                    "budget":3176361,
-                    "salary_max":580000,
-                    "salary_max_position":"M-F",
-                    "salary_max_player":"Federico Higuain"
-                },
-                "NE":{
-                    "salary_avg":{
-                        "D":143669,
-                        "GK":60276,
-                        "M":347929,
-                        "F":116454
-                    },
-                    "budget":6362933,
-                    "salary_max":3000000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Jermaine Jones"
-                },
-                "KC":{
-                    "salary_avg":{
-                        "D":151695,
-                        "GK":91666,
-                        "M":157944,
-                        "F":176878
-                    },
-                    "budget":4143312,
-                    "salary_max":600000,
-                    "salary_max_position":"D",
-                    "salary_max_player":"Matt Besler"
-                },
-                "SEA":{
-                    "salary_avg":{
-                        "D":94829,
-                        "GK":87833,
-                        "M":114118,
-                        "F":810130
-                    },
-                    "budget":9396634,
-                    "salary_max":4913004,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Clint Dempsey"
-                },
-                "DC":{
-                    "salary_avg":{
-                        "D":99541,
-                        "GK":65883,
-                        "M":118752,
-                        "F":194403
-                    },
-                    "budget":3471746,
-                    "salary_max":505000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Eddie Johnson"
-                },
-                "POR":{
-                    "salary_avg":{
-                        "D":195969,
-                        "GK":124833,
-                        "M":153000,
-                        "F":218570
-                    },
-                    "budget":5283726,
-                    "salary_max":1200000,
-                    "salary_max_position":"D",
-                    "salary_max_player":"Liam Ridgewell"
-                },
-                "PHI":{
-                    "salary_avg":{
-                        "D":112401,
-                        "GK":145000,
-                        "M":156929,
-                        "F":113468
-                    },
-                    "budget":4073098,
-                    "salary_max":650000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Maurice Edu"
-                },
-                "TOR":{
-                    "salary_avg":{
-                        "D":115732,
-                        "GK":78834,
-                        "M":818520,
-                        "F":873348
-                    },
-                    "budget":15686628,
-                    "salary_max":6000000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Michael Bradley"
-                },
-                "MTL":{
-                    "salary_avg":{
-                        "D":137032,
-                        "GK":115775,
-                        "M":110047,
-                        "F":298572
-                    },
-                    "budget":5080914,
-                    "salary_max":1500000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Marco Di Vaio"
-                },
-                "CHV":{
-                    "salary_avg":{
-                        "D":146550,
-                        "GK":124127,
-                        "M":129100,
-                        "F":65185
-                    },
-                    "budget":3077432,
-                    "salary_max":400000,
-                    "salary_max_position":"D-M",
-                    "salary_max_player":"Nigel Reo-Coker"
-                },
-                "DAL":{
-                    "salary_avg":{
-                        "D":104002,
-                        "GK":104500,
-                        "M":114458,
-                        "F":192251
-                    },
-                    "budget":4041037,
-                    "salary_max":625000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Andres Escobar"
-                },
-                "SJ":{
-                    "salary_avg":{
-                        "D":120750,
-                        "GK":86041,
-                        "M":174519,
-                        "F":106108
-                    },
-                    "budget":3957076,
-                    "salary_max":600000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Chris Wondolowski"
-                },
-                "NYCFC":{
-                    "salary_avg":{
-                        "D":55000,
-                        "GK":48504,
-                        "M":147500,
-                        "F":60000
-                    },
-                    "budget":458504,
-                    "salary_max":180000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Andrew Jacobson"
-                },
-                "CHI":{
-                    "salary_avg":{
-                        "D":133415,
-                        "GK":124166,
-                        "M":88546,
-                        "F":143666
-                    },
-                    "budget":3529746,
-                    "salary_max":350000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Mike Magee"
-                },
-                "POOL":{
-                    "salary_avg":{
-                        "GK":36504
-                    },
-                    "budget":36504,
-                    "salary_max":36504,
-                    "salary_max_position":"GK",
-                    "salary_max_player":"Daniel Withrow"
-                },
-                "LA":{
-                    "salary_avg":{
-                        "D":183797,
-                        "GK":81275,
-                        "M":136282,
-                        "F":865772
-                    },
-                    "budget":12375473,
-                    "salary_max":4500000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Robbie Keane"
-                },
-                "ORL":{
-                    "salary_avg":{
-                        "D":36500,
-                        "M":1704625
-                    },
-                    "budget":6855000,
-                    "salary_max":6660000,
-                    "salary_max_position":"M",
-                    "salary_max_player":" Kaka"
-                },
-                "NY":{
-                    "salary_avg":{
-                        "D":117689,
-                        "GK":68250,
-                        "M":435965,
-                        "F":891729
-                    },
-                    "budget":10268811,
-                    "salary_max":3750000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Thierry Henry"
-                },
-                "HOU":{
-                    "salary_avg":{
-                        "D":197000,
-                        "GK":108834,
-                        "M":156704,
-                        "F":125803
-                    },
-                    "budget":4027369,
-                    "salary_max":750000,
-                    "salary_max_position":"D",
-                    "salary_max_player":"DaMarcus Beasley"
-                },
-                "VAN":{
-                    "salary_avg":{
-                        "D":115452,
-                        "GK":119501,
-                        "M":227221,
-                        "F":72331
-                    },
-                    "budget":4542729,
-                    "salary_max":1190000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Pedro Morales"
-                },
-                "RSL":{
-                    "salary_avg":{
-                        "D":111255,
-                        "GK":103441,
-                        "M":144350,
-                        "F":136444
-                    },
-                    "budget":3647515,
-                    "salary_max":360000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Alvaro Saborio"
-                },
-                "COL":{
-                    "salary_avg":{
-                        "D":102759,
-                        "GK":53833,
-                        "M":80216,
-                        "F":173137
-                    },
-                    "budget":3007541,
-                    "salary_max":325000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Edson Buddle"
-                }
-            },
-            "2007":{
-                "CLB":{
-                    "salary_avg":{
-                        "D":78000,
-                        "GK":26190,
-                        "M":60979,
-                        "F":70606
-                    },
-                    "budget":1889550,
-                    "salary_max":165000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Eddie Gaven"
-                },
-                "DAL":{
-                    "salary_avg":{
-                        "D":49026,
-                        "GK":116166,
-                        "M":120633,
-                        "F":89285
-                    },
-                    "budget":2790739,
-                    "salary_max":872736,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Denilson De Oliveira"
-                },
-                "Pool":{
-                    "salary_avg":{
-                        "GK":20775
-                    },
-                    "budget":83100,
-                    "salary_max":30000,
-                    "salary_max_position":"GK",
-                    "salary_max_player":"David Monsalve"
-                },
-                "NE":{
-                    "salary_avg":{
-                        "D":71358,
-                        "GK":70966,
-                        "M":40207,
-                        "F":92009
-                    },
-                    "budget":1850848,
-                    "salary_max":325008,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Taylor Twellman"
-                },
-                "KC":{
-                    "salary_avg":{
-                        "D":78857,
-                        "GK":64300,
-                        "M":55029,
-                        "F":103222
-                    },
-                    "budget":2441925,
-                    "salary_max":750000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Eddie Johnson"
-                },
-                "LA":{
-                    "salary_avg":{
-                        "D":73362,
-                        "GK":79876,
-                        "M":578695,
-                        "F":196124
-                    },
-                    "budget":8229548,
-                    "salary_max":5500000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"David Beckham"
-                },
-                "DC":{
-                    "salary_avg":{
-                        "D":70072,
-                        "GK":44633,
-                        "M":71291,
-                        "F":95297
-                    },
-                    "budget":2101315,
-                    "salary_max":265000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Luciano Emilio"
-                },
-                "TFC":{
-                    "salary_avg":{
-                        "D":75225,
-                        "GK":57566,
-                        "M":89510,
-                        "F":122500
-                    },
-                    "budget":2310050,
-                    "salary_max":300000,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Carl Robinson"
-                },
-                "HOU":{
-                    "salary_avg":{
-                        "D":91579,
-                        "GK":77100,
-                        "M":78746,
-                        "F":98509
-                    },
-                    "budget":2350046,
-                    "salary_max":324999,
-                    "salary_max_position":"M",
-                    "salary_max_player":"Dwayne DeRosario"
-                },
-                "CHI":{
-                    "salary_avg":{
-                        "D":67421,
-                        "GK":34416,
-                        "M":82840,
-                        "F":483204
-                    },
-                    "budget":4412517,
-                    "salary_max":2492316,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Cuauhtemoc Blanco"
-                },
-                "RSL":{
-                    "salary_avg":{
-                        "D":68722,
-                        "GK":45608,
-                        "M":66371,
-                        "F":57056
-                    },
-                    "budget":1798530,
-                    "salary_max":265000,
-                    "salary_max_position":"D",
-                    "salary_max_player":"Eddie Pope"
-                },
-                "COL":{
-                    "salary_avg":{
-                        "D":77840,
-                        "GK":33500,
-                        "M":85244,
-                        "F":101881
-                    },
-                    "budget":2181153,
-                    "salary_max":280000,
-                    "salary_max_position":"M-D",
-                    "salary_max_player":"Pablo Mastroeni"
-                },
-                "NY":{
-                    "salary_avg":{
-                        "D":44232,
-                        "GK":92633,
-                        "M":152877,
-                        "F":199848
-                    },
-                    "budget":4360735,
-                    "salary_max":1500000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Juan Pablo Angel"
-                },
-                "CHV":{
-                    "salary_avg":{
-                        "D":55426,
-                        "GK":39209,
-                        "M":61416,
-                        "F":68516
-                    },
-                    "budget":1678269,
-                    "salary_max":245000,
-                    "salary_max_position":"F",
-                    "salary_max_player":"Ante Razov"
+            "teams": {
+                "2016": {
+                    "CLB": {
+                        "salary_avg": {
+                            "D": 229714,
+                            "GK": 111499,
+                            "M": 239568,
+                            "F": 235000
+                        },
+                        "budget": 5282748,
+                        "salary_max": 1175000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Federico Higuain"
+                    },
+                    "NE": {
+                        "salary_avg": {
+                            "D": 143000,
+                            "GK": 91701,
+                            "M": 228300,
+                            "F": 256179
+                        },
+                        "budget": 5564046,
+                        "salary_max": 1000000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Kei Kamara"
+                    },
+                    "KC": {
+                        "salary_avg": {
+                            "D": 184055,
+                            "GK": 98583,
+                            "M": 269649,
+                            "F": 337850
+                        },
+                        "budget": 6309194,
+                        "salary_max": 800000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Roger Espinoza"
+                    },
+                    "SEA": {
+                        "salary_avg": {
+                            "D": 148325,
+                            "GK": 105002,
+                            "M": 225519,
+                            "F": 730252
+                        },
+                        "budget": 9479113,
+                        "salary_max": 3913008,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Clint Dempsey"
+                    },
+                    "ATL": {
+                        "salary_avg": {
+                            "GK": 63000,
+                            "M": 57006
+                        },
+                        "budget": 177012,
+                        "salary_max": 63000,
+                        "salary_max_position": "GK",
+                        "salary_max_player": "Alexander Tambakis"
+                    },
+                    "DC": {
+                        "salary_avg": {
+                            "D": 125968,
+                            "GK": 119694,
+                            "M": 168078,
+                            "F": 199586
+                        },
+                        "budget": 4552163,
+                        "salary_max": 420000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Alvaro Saborio"
+                    },
+                    "NYRB": {
+                        "salary_avg": {
+                            "D": 155500,
+                            "GK": 134248,
+                            "M": 234150,
+                            "F": 248750
+                        },
+                        "budget": 5186746,
+                        "salary_max": 650000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Bradley Wright-Phillips"
+                    },
+                    "PHI": {
+                        "salary_avg": {
+                            "D": 100062,
+                            "GK": 84666,
+                            "M": 264200,
+                            "F": 251250
+                        },
+                        "budget": 5242500,
+                        "salary_max": 725000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Maurice Edu"
+                    },
+                    "POR": {
+                        "salary_avg": {
+                            "D": 203924,
+                            "GK": 159353,
+                            "M": 187458,
+                            "F": 360500
+                        },
+                        "budget": 6547661,
+                        "salary_max": 1100000,
+                        "salary_max_position": "D",
+                        "salary_max_player": "Liam Ridgewell"
+                    },
+                    "MTL": {
+                        "salary_avg": {
+                            "D": 193642,
+                            "GK": 105066,
+                            "M": 176303,
+                            "F": 330457
+                        },
+                        "budget": 5936300,
+                        "salary_max": 1666667,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Didier Drogba"
+                    },
+                    "DAL": {
+                        "salary_avg": {
+                            "D": 142000,
+                            "GK": 88669,
+                            "M": 154917,
+                            "F": 95974
+                        },
+                        "budget": 3746282,
+                        "salary_max": 466000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Mauro Diaz"
+                    },
+                    "SJ": {
+                        "salary_avg": {
+                            "D": 138361,
+                            "GK": 92666,
+                            "M": 186280,
+                            "F": 325071
+                        },
+                        "budget": 5821616,
+                        "salary_max": 988000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Innocent Emeghara"
+                    },
+                    "NYCFC": {
+                        "salary_avg": {
+                            "D": 136861,
+                            "GK": 91669,
+                            "M": 1291388,
+                            "F": 1214605
+                        },
+                        "budget": 20603922,
+                        "salary_max": 6000000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Frank Lampard"
+                    },
+                    "CHI": {
+                        "salary_avg": {
+                            "D": 131038,
+                            "GK": 131250,
+                            "M": 154458,
+                            "F": 690000
+                        },
+                        "budget": 5292596,
+                        "salary_max": 1145000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Gilberto Junior"
+                    },
+                    "POOL": {
+                        "salary_avg": {
+                            "GK": 62500
+                        },
+                        "budget": 62500,
+                        "salary_max": 62500,
+                        "salary_max_position": "GK",
+                        "salary_max_player": "Trey Mitchell"
+                    },
+                    "LA": {
+                        "salary_avg": {
+                            "D": 189812,
+                            "GK": 107500,
+                            "M": 841111,
+                            "F": 725950
+                        },
+                        "budget": 16110500,
+                        "salary_max": 6000000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Steven Gerrard"
+                    },
+                    "TOR": {
+                        "salary_avg": {
+                            "D": 168305,
+                            "GK": 74333,
+                            "M": 886593,
+                            "F": 1784025
+                        },
+                        "budget": 19534650,
+                        "salary_max": 6000000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Michael Bradley"
+                    },
+                    "ORL": {
+                        "salary_avg": {
+                            "D": 173900,
+                            "GK": 81333,
+                            "M": 598066,
+                            "F": 106100
+                        },
+                        "budget": 10656500,
+                        "salary_max": 6660000,
+                        "salary_max_position": "M",
+                        "salary_max_player": " Kaka"
+                    },
+                    "HOU": {
+                        "salary_avg": {
+                            "D": 209324,
+                            "GK": 105333,
+                            "M": 180921,
+                            "F": 372000
+                        },
+                        "budget": 5312577,
+                        "salary_max": 750000,
+                        "salary_max_position": "D",
+                        "salary_max_player": "DaMarcus Beasley"
+                    },
+                    "VAN": {
+                        "salary_avg": {
+                            "D": 114000,
+                            "GK": 161833,
+                            "M": 224042,
+                            "F": 286240
+                        },
+                        "budget": 6012441,
+                        "salary_max": 1232500,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Pedro Morales"
+                    },
+                    "RSL": {
+                        "salary_avg": {
+                            "D": 128055,
+                            "GK": 184333,
+                            "M": 233687,
+                            "F": 260714
+                        },
+                        "budget": 5337500,
+                        "salary_max": 1060000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Juan Manuel Martinez"
+                    },
+                    "COL": {
+                        "salary_avg": {
+                            "D": 94309,
+                            "GK": 588625,
+                            "M": 260147,
+                            "F": 270894
+                        },
+                        "budget": 7715259,
+                        "salary_max": 2100000,
+                        "salary_max_position": "GK",
+                        "salary_max_player": "Tim Howard"
+                    }
+                },
+                "2015": {
+                    "DAL": {
+                        "salary_avg": {
+                            "D": 117500,
+                            "GK": 141000,
+                            "M": 131999,
+                            "F": 164714
+                        },
+                        "budget": 3669999,
+                        "salary_max": 364000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Mauro Diaz"
+                    },
+                    "CLB": {
+                        "salary_avg": {
+                            "D": 187744,
+                            "GK": 96666,
+                            "M": 200811,
+                            "F": 291669
+                        },
+                        "budget": 5296983,
+                        "salary_max": 1175000,
+                        "salary_max_position": "M-F",
+                        "salary_max_player": "Federico Higuain"
+                    },
+                    "LA": {
+                        "salary_avg": {
+                            "D": 255000,
+                            "GK": 107500,
+                            "M": 1121500,
+                            "F": 660000
+                        },
+                        "budget": 18965008,
+                        "salary_max": 6200004,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Steven Gerrard"
+                    },
+                    "SJ": {
+                        "salary_avg": {
+                            "D": 168500,
+                            "GK": 80000,
+                            "M": 168684,
+                            "F": 192329
+                        },
+                        "budget": 4821892,
+                        "salary_max": 988000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Innocent Emeghara"
+                    },
+                    "NYCFC": {
+                        "salary_avg": {
+                            "D": 136875,
+                            "GK": 70554,
+                            "M": 752365,
+                            "F": 1458750
+                        },
+                        "budget": 16922421,
+                        "salary_max": 6000000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Frank Lampard"
+                    },
+                    "NE": {
+                        "salary_avg": {
+                            "D": 148928,
+                            "GK": 77751,
+                            "M": 346045,
+                            "F": 143156
+                        },
+                        "budget": 5871005,
+                        "salary_max": 2800000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Jermaine Jones"
+                    },
+                    "VAN": {
+                        "salary_avg": {
+                            "D": 122900,
+                            "GK": 142000,
+                            "M": 208188,
+                            "F": 176846
+                        },
+                        "budget": 5526615,
+                        "salary_max": 1190000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Pedro Morales"
+                    },
+                    "SEA": {
+                        "salary_avg": {
+                            "D": 132579,
+                            "GK": 115000,
+                            "M": 181600,
+                            "F": 976834
+                        },
+                        "budget": 11434048,
+                        "salary_max": 3913008,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Clint Dempsey"
+                    },
+                    "POOL": {
+                        "salary_avg": {
+                            "GK": 50000
+                        },
+                        "budget": 50000,
+                        "salary_max": 50000,
+                        "salary_max_position": "GK",
+                        "salary_max_player": "Trey Mitchell"
+                    },
+                    "ORL": {
+                        "salary_avg": {
+                            "D": 192619,
+                            "GK": 108333,
+                            "M": 552985,
+                            "F": 102000
+                        },
+                        "budget": 10388355,
+                        "salary_max": 6660000,
+                        "salary_max_position": "M",
+                        "salary_max_player": " Kaka"
+                    },
+                    "COL": {
+                        "salary_avg": {
+                            "D": 115943,
+                            "GK": 91666,
+                            "M": 148181,
+                            "F": 262429
+                        },
+                        "budget": 4655492,
+                        "salary_max": 1125000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Kevin Doyle"
+                    },
+                    "DC": {
+                        "salary_avg": {
+                            "D": 108833,
+                            "GK": 156666,
+                            "M": 149667,
+                            "F": 226666
+                        },
+                        "budget": 3791509,
+                        "salary_max": 400000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Alvaro Saborio"
+                    },
+                    "POR": {
+                        "salary_avg": {
+                            "D": 192000,
+                            "GK": 130866,
+                            "M": 160559,
+                            "F": 307436
+                        },
+                        "budget": 5748125,
+                        "salary_max": 1000000,
+                        "salary_max_position": "D",
+                        "salary_max_player": "Liam Ridgewell"
+                    },
+                    "PHI": {
+                        "salary_avg": {
+                            "D": 151377,
+                            "GK": 68333,
+                            "M": 204838,
+                            "F": 165500
+                        },
+                        "budget": 5057423,
+                        "salary_max": 700000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Maurice Edu"
+                    },
+                    "MTL": {
+                        "salary_avg": {
+                            "D": 152546,
+                            "GK": 97333,
+                            "M": 150990,
+                            "F": 312708
+                        },
+                        "budget": 5467536,
+                        "salary_max": 1666668,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Didier Drogba"
+                    },
+                    "HOU": {
+                        "salary_avg": {
+                            "D": 216109,
+                            "GK": 85000,
+                            "M": 143354,
+                            "F": 166666
+                        },
+                        "budget": 4632875,
+                        "salary_max": 750000,
+                        "salary_max_position": "D",
+                        "salary_max_player": "DaMarcus Beasley"
+                    },
+                    "KC": {
+                        "salary_avg": {
+                            "D": 160500,
+                            "GK": 82500,
+                            "M": 247692,
+                            "F": 355875
+                        },
+                        "budget": 5453500,
+                        "salary_max": 750000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Roger Espinoza"
+                    },
+                    "TOR": {
+                        "salary_avg": {
+                            "D": 154777,
+                            "GK": 84000,
+                            "M": 1245493,
+                            "F": 815419
+                        },
+                        "budget": 19761936,
+                        "salary_max": 6000000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Michael Bradley"
+                    },
+                    "RSL": {
+                        "salary_avg": {
+                            "D": 125555,
+                            "GK": 156666,
+                            "M": 168888,
+                            "F": 198571
+                        },
+                        "budget": 4598884,
+                        "salary_max": 710000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Juan Manuel Martinez"
+                    },
+                    "CHI": {
+                        "salary_avg": {
+                            "D": 111237,
+                            "GK": 131666,
+                            "M": 93735,
+                            "F": 481784
+                        },
+                        "budget": 5389775,
+                        "salary_max": 1144992,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Gilberto Junior"
+                    },
+                    "NY": {
+                        "salary_avg": {
+                            "D": 87876,
+                            "GK": 92000,
+                            "M": 143834,
+                            "F": 203475
+                        },
+                        "budget": 3753746,
+                        "salary_max": 600000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Bradley Wright-Phillips"
+                    }
+                },
+                "2012": {
+                    "CLB": {
+                        "salary_avg": {
+                            "D": 123123,
+                            "GK": 97000,
+                            "M": 103295,
+                            "F": 112683
+                        },
+                        "budget": 3111134,
+                        "salary_max": 310000,
+                        "salary_max_position": "D",
+                        "salary_max_player": "Chad Marshall"
+                    },
+                    "NE": {
+                        "salary_avg": {
+                            "D": 73607,
+                            "GK": 81733,
+                            "M": 114282,
+                            "F": 77487
+                        },
+                        "budget": 2284905,
+                        "salary_max": 400000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Benny Feilhaber"
+                    },
+                    "LA": {
+                        "salary_avg": {
+                            "D": 107343,
+                            "GK": 61431,
+                            "M": 349965,
+                            "F": 628312
+                        },
+                        "budget": 10825821,
+                        "salary_max": 3000000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "David Beckham"
+                    },
+                    "SJ": {
+                        "salary_avg": {
+                            "D": 92300,
+                            "GK": 86586,
+                            "M": 100970,
+                            "F": 91551
+                        },
+                        "budget": 2878166,
+                        "salary_max": 300000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Chris Wondolowski"
+                    },
+                    "TFC": {
+                        "salary_avg": {
+                            "D": 330000,
+                            "GK": 44004
+                        },
+                        "budget": 374004,
+                        "salary_max": 330000,
+                        "salary_max_position": "D",
+                        "salary_max_player": "Darren O'Dea"
+                    },
+                    "KC": {
+                        "salary_avg": {
+                            "D": 104695,
+                            "GK": 105450,
+                            "M": 91818,
+                            "F": 95000
+                        },
+                        "budget": 2893657,
+                        "salary_max": 252000,
+                        "salary_max_position": "D",
+                        "salary_max_player": "Julio Cesar"
+                    },
+                    "SEA": {
+                        "salary_avg": {
+                            "D": 101493,
+                            "GK": 77949,
+                            "M": 138262,
+                            "F": 138025
+                        },
+                        "budget": 3789781,
+                        "salary_max": 600000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Fredy Montero"
+                    },
+                    "POOL": {
+                        "salary_avg": {
+                            "GK": 37202
+                        },
+                        "budget": 111606,
+                        "salary_max": 44100,
+                        "salary_max_position": "GK",
+                        "salary_max_player": "Chris Sharpe"
+                    },
+                    "COL": {
+                        "salary_avg": {
+                            "D": 125116,
+                            "GK": 88880,
+                            "M": 94799,
+                            "F": 164799
+                        },
+                        "budget": 3111123,
+                        "salary_max": 400000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Conor Casey"
+                    },
+                    "DC": {
+                        "salary_avg": {
+                            "D": 108231,
+                            "GK": 52701,
+                            "M": 140066,
+                            "F": 145837
+                        },
+                        "budget": 3453679,
+                        "salary_max": 617857,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Dwayne DeRosario"
+                    },
+                    "POR": {
+                        "salary_avg": {
+                            "D": 81143,
+                            "GK": 118833,
+                            "M": 71593,
+                            "F": 211386
+                        },
+                        "budget": 3776116,
+                        "salary_max": 1250000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Kris Boyd"
+                    },
+                    "DAL": {
+                        "salary_avg": {
+                            "D": 93247,
+                            "GK": 94666,
+                            "M": 299861,
+                            "F": 164157
+                        },
+                        "budget": 4865549,
+                        "salary_max": 1863996,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Julian de Guzman"
+                    },
+                    "PHI": {
+                        "salary_avg": {
+                            "D": 143350,
+                            "GK": 59333,
+                            "M": 113375,
+                            "F": 63166
+                        },
+                        "budget": 2861006,
+                        "salary_max": 400000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Freddy Adu"
+                    },
+                    "MTL": {
+                        "salary_avg": {
+                            "D": 90575,
+                            "GK": 99666,
+                            "M": 93667,
+                            "F": 225747
+                        },
+                        "budget": 3453853,
+                        "salary_max": 1000008,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Marco Di Vaio"
+                    },
+                    "HOU": {
+                        "salary_avg": {
+                            "D": 105604,
+                            "GK": 65950,
+                            "M": 116767,
+                            "F": 108247
+                        },
+                        "budget": 2901166,
+                        "salary_max": 265000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Brad Davis"
+                    },
+                    "VAN": {
+                        "salary_avg": {
+                            "D": 141231,
+                            "GK": 85000,
+                            "M": 129409,
+                            "F": 257914
+                        },
+                        "budget": 4551665,
+                        "salary_max": 1221816,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Kenny Miller"
+                    },
+                    "TOR": {
+                        "salary_avg": {
+                            "D": 81825,
+                            "GK": 65950,
+                            "M": 293423,
+                            "F": 280314
+                        },
+                        "budget": 5455463,
+                        "salary_max": 2000000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Torsten Frings"
+                    },
+                    "RSL": {
+                        "salary_avg": {
+                            "D": 127067,
+                            "GK": 89916,
+                            "M": 121113,
+                            "F": 137642
+                        },
+                        "budget": 3206785,
+                        "salary_max": 425000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Javier Morales"
+                    },
+                    "CHI": {
+                        "salary_avg": {
+                            "D": 105328,
+                            "GK": 67333,
+                            "M": 111233,
+                            "F": 151859
+                        },
+                        "budget": 3600214,
+                        "salary_max": 360000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Sherjill MacDonald"
+                    },
+                    "NY": {
+                        "salary_avg": {
+                            "D": 608222,
+                            "GK": 45437,
+                            "M": 465486,
+                            "F": 924625
+                        },
+                        "budget": 15814368,
+                        "salary_max": 5000000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Thierry Henry"
+                    },
+                    "CHV": {
+                        "salary_avg": {
+                            "D": 109083,
+                            "GK": 84250,
+                            "M": 113066,
+                            "F": 117416
+                        },
+                        "budget": 3047728,
+                        "salary_max": 495000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Shalrie Joseph"
+                    }
+                },
+                "2011": {
+                    "CLB": {
+                        "salary_avg": {
+                            "D": 81666,
+                            "GK": 83366,
+                            "M": 89433,
+                            "F": 154829
+                        },
+                        "budget": 3004123,
+                        "salary_max": 500000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Andres Mendoza"
+                    },
+                    "NE": {
+                        "salary_avg": {
+                            "D": 68500,
+                            "GK": 90437,
+                            "M": 138410,
+                            "F": 87098
+                        },
+                        "budget": 2698503,
+                        "salary_max": 475000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Shalrie Joseph"
+                    },
+                    "SJ": {
+                        "salary_avg": {
+                            "D": 73443,
+                            "GK": 90001,
+                            "M": 108722,
+                            "F": 78172
+                        },
+                        "budget": 2600712,
+                        "salary_max": 313500,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Bobby Convey"
+                    },
+                    "TFC": {
+                        "salary_avg": {
+                            "D": 71191,
+                            "GK": 71000,
+                            "M": 254958,
+                            "F": 196009
+                        },
+                        "budget": 5440626,
+                        "salary_max": 1863996,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Julian de Guzman"
+                    },
+                    "VAN": {
+                        "salary_avg": {
+                            "D": 91547,
+                            "GK": 99033,
+                            "M": 107421,
+                            "F": 209685
+                        },
+                        "budget": 3566997,
+                        "salary_max": 660000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Eric Hassli"
+                    },
+                    "SEA": {
+                        "salary_avg": {
+                            "D": 89395,
+                            "GK": 108201,
+                            "M": 84320,
+                            "F": 108382
+                        },
+                        "budget": 3033191,
+                        "salary_max": 500000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Fredy Montero"
+                    },
+                    "POOL": {
+                        "salary_avg": {
+                            "GK": 42000
+                        },
+                        "budget": 126000,
+                        "salary_max": 42000,
+                        "salary_max_position": "GK",
+                        "salary_max_player": "Kevin Guppy"
+                    },
+                    "LA": {
+                        "salary_avg": {
+                            "D": 78744,
+                            "GK": 101490,
+                            "M": 608195,
+                            "F": 716886
+                        },
+                        "budget": 12830222,
+                        "salary_max": 5500000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "David Beckham"
+                    },
+                    "DC": {
+                        "salary_avg": {
+                            "D": 73094,
+                            "GK": 56333,
+                            "M": 138108,
+                            "F": 129660
+                        },
+                        "budget": 2958886,
+                        "salary_max": 425000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Dwayne DeRosario"
+                    },
+                    "POR": {
+                        "salary_avg": {
+                            "D": 77075,
+                            "GK": 121333,
+                            "M": 64538,
+                            "F": 84400
+                        },
+                        "budget": 2299670,
+                        "salary_max": 250000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Kenny Cooper"
+                    },
+                    "TOR": {
+                        "salary_avg": {
+                            "D": 68596,
+                            "M": 55000
+                        },
+                        "budget": 123596,
+                        "salary_max": 68596,
+                        "salary_max_position": "D",
+                        "salary_max_player": "Andy Iro"
+                    },
+                    "DAL": {
+                        "salary_avg": {
+                            "D": 87400,
+                            "GK": 96900,
+                            "M": 122687,
+                            "F": 141429
+                        },
+                        "budget": 2863854,
+                        "salary_max": 600000,
+                        "salary_max_position": "M-F",
+                        "salary_max_player": "David Ferreira"
+                    },
+                    "PHI": {
+                        "salary_avg": {
+                            "D": 165250,
+                            "GK": 155000,
+                            "M": 123191,
+                            "F": 64743
+                        },
+                        "budget": 2870942,
+                        "salary_max": 475884,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Freddy Adu"
+                    },
+                    "HOU": {
+                        "salary_avg": {
+                            "D": 122916,
+                            "GK": 53200,
+                            "M": 102546,
+                            "F": 172343
+                        },
+                        "budget": 3059176,
+                        "salary_max": 375000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Brian Ching"
+                    },
+                    "KC": {
+                        "salary_avg": {
+                            "D": 85735,
+                            "GK": 101500,
+                            "M": 87139,
+                            "F": 136450
+                        },
+                        "budget": 3109530,
+                        "salary_max": 429996,
+                        "salary_max_position": "F",
+                        "salary_max_player": " Jeferson"
+                    },
+                    "CHI": {
+                        "salary_avg": {
+                            "D": 77178,
+                            "GK": 59200,
+                            "M": 93226,
+                            "F": 91514
+                        },
+                        "budget": 2538304,
+                        "salary_max": 240000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Cristian Nazarit"
+                    },
+                    "RSL": {
+                        "salary_avg": {
+                            "D": 103262,
+                            "GK": 80666,
+                            "M": 137443,
+                            "F": 101159
+                        },
+                        "budget": 2946031,
+                        "salary_max": 400000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Javier Morales"
+                    },
+                    "COL": {
+                        "salary_avg": {
+                            "D": 99505,
+                            "GK": 89083,
+                            "M": 85461,
+                            "F": 148406
+                        },
+                        "budget": 2991458,
+                        "salary_max": 400000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Conor Casey"
+                    },
+                    "NY": {
+                        "salary_avg": {
+                            "D": 559545,
+                            "GK": 207978,
+                            "M": 107601,
+                            "F": 795571
+                        },
+                        "budget": 12583039,
+                        "salary_max": 5000000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Thierry Henry"
+                    },
+                    "CHV": {
+                        "salary_avg": {
+                            "D": 114304,
+                            "GK": 87498,
+                            "M": 75571,
+                            "F": 174067
+                        },
+                        "budget": 3346214,
+                        "salary_max": 1000000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Juan Pablo Angel"
+                    }
+                },
+                "2010": {
+                    "DAL": {
+                        "salary_avg": {
+                            "D": 79838,
+                            "GK": 103333,
+                            "M": 87935,
+                            "F": 112246
+                        },
+                        "budget": 2517610,
+                        "salary_max": 300000,
+                        "salary_max_position": "M-F",
+                        "salary_max_player": "David Ferreira"
+                    },
+                    "NE": {
+                        "salary_avg": {
+                            "D": 63041,
+                            "GK": 83002,
+                            "M": 101364,
+                            "F": 133944
+                        },
+                        "budget": 2795765,
+                        "salary_max": 450000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Shalrie Joseph"
+                    },
+                    "SJ": {
+                        "salary_avg": {
+                            "D": 68714,
+                            "GK": 137000,
+                            "M": 103944,
+                            "F": 113584
+                        },
+                        "budget": 2273338,
+                        "salary_max": 285000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Bobby Convey"
+                    },
+                    "Pool": {
+                        "salary_avg": {
+                            "GK": 40000
+                        },
+                        "budget": 120000,
+                        "salary_max": 40000,
+                        "salary_max_position": "GK",
+                        "salary_max_player": "Kevin Guppy"
+                    },
+                    "CLB": {
+                        "salary_avg": {
+                            "D": 99622,
+                            "GK": 82500,
+                            "M": 107155,
+                            "F": 126367
+                        },
+                        "budget": 2372912,
+                        "salary_max": 250000,
+                        "salary_max_position": "D",
+                        "salary_max_player": "Chad Marshall"
+                    },
+                    "None": {
+                        "salary_avg": {
+                            "D": 102355,
+                            "F": 88000
+                        },
+                        "budget": 292710,
+                        "salary_max": 120000,
+                        "salary_max_position": "D",
+                        "salary_max_player": "Kevin Goldthwaite"
+                    },
+                    "KC": {
+                        "salary_avg": {
+                            "D": 90186,
+                            "GK": 78000,
+                            "M": 94151,
+                            "F": 128287
+                        },
+                        "budget": 2583878,
+                        "salary_max": 232750,
+                        "salary_max_position": "D",
+                        "salary_max_player": "Jimmy Conrad"
+                    },
+                    "SEA": {
+                        "salary_avg": {
+                            "D": 81958,
+                            "GK": 170000,
+                            "M": 95703,
+                            "F": 125600
+                        },
+                        "budget": 2980515,
+                        "salary_max": 480000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Blaise Nkufo"
+                    },
+                    "LA": {
+                        "salary_avg": {
+                            "D": 84829,
+                            "GK": 89908,
+                            "M": 867214,
+                            "F": 370135
+                        },
+                        "budget": 9609808,
+                        "salary_max": 5500000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "David Beckham"
+                    },
+                    "DC": {
+                        "salary_avg": {
+                            "D": 66539,
+                            "GK": 93336,
+                            "M": 105400,
+                            "F": 113000
+                        },
+                        "budget": 2540939,
+                        "salary_max": 380000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Branko Boskovic"
+                    },
+                    "PHI": {
+                        "salary_avg": {
+                            "D": 122500,
+                            "GK": 70000,
+                            "M": 99834,
+                            "F": 136812
+                        },
+                        "budget": 2370262,
+                        "salary_max": 250000,
+                        "salary_max_position": "D",
+                        "salary_max_player": "Daniel Califf"
+                    },
+                    "HOU": {
+                        "salary_avg": {
+                            "D": 126200,
+                            "GK": 88000,
+                            "M": 84875,
+                            "F": 136750
+                        },
+                        "budget": 2388500,
+                        "salary_max": 350000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Brian Ching"
+                    },
+                    "CHI": {
+                        "salary_avg": {
+                            "D": 75217,
+                            "GK": 47500,
+                            "M": 416875,
+                            "F": 309893
+                        },
+                        "budget": 4836214,
+                        "salary_max": 1400004,
+                        "salary_max_position": "M-F",
+                        "salary_max_player": "Nery Castillo"
+                    },
+                    "TFC": {
+                        "salary_avg": {
+                            "D": 71659,
+                            "GK": 60000,
+                            "M": 333256,
+                            "F": 266122
+                        },
+                        "budget": 4786124,
+                        "salary_max": 1670796,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Julian de Guzman"
+                    },
+                    "RSL": {
+                        "salary_avg": {
+                            "D": 99875,
+                            "GK": 66666,
+                            "M": 103770,
+                            "F": 72330
+                        },
+                        "budget": 2346344,
+                        "salary_max": 250000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Kyle Beckerman"
+                    },
+                    "COL": {
+                        "salary_avg": {
+                            "D": 103770,
+                            "GK": 76333,
+                            "M": 95372,
+                            "F": 110250
+                        },
+                        "budget": 2434050,
+                        "salary_max": 350000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Conor Casey"
+                    },
+                    "NY": {
+                        "salary_avg": {
+                            "D": 849893,
+                            "GK": 113500,
+                            "M": 95761,
+                            "F": 903000
+                        },
+                        "budget": 14470151,
+                        "salary_max": 5544000,
+                        "salary_max_position": "D",
+                        "salary_max_player": "Rafael Marquez"
+                    },
+                    "CHV": {
+                        "salary_avg": {
+                            "D": 87285,
+                            "GK": 99998,
+                            "M": 83966,
+                            "F": 87653
+                        },
+                        "budget": 2389825,
+                        "salary_max": 216000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Rodolfo Espinoza"
+                    }
+                },
+                "2017": {
+                    "CLB": {
+                        "salary_avg": {
+                            "D": 251550,
+                            "GK": 79336,
+                            "M": 213158,
+                            "F": 186593
+                        },
+                        "budget": 6345232,
+                        "salary_max": 1050000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Federico Higuain"
+                    },
+                    "NE": {
+                        "salary_avg": {
+                            "D": 227844,
+                            "GK": 77492,
+                            "M": 227177,
+                            "F": 279220
+                        },
+                        "budget": 5406993,
+                        "salary_max": 840000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Xavier Kouassi"
+                    },
+                    "KC": {
+                        "salary_avg": {
+                            "D": 164782,
+                            "GK": 99334,
+                            "M": 468286,
+                            "F": 200377
+                        },
+                        "budget": 6223848,
+                        "salary_max": 850000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Roger Espinoza"
+                    },
+                    "SEA": {
+                        "salary_avg": {
+                            "D": 174837,
+                            "GK": 127261,
+                            "M": 313017,
+                            "F": 773725
+                        },
+                        "budget": 8986700,
+                        "salary_max": 3200000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Clint Dempsey"
+                    },
+                    "ATL": {
+                        "salary_avg": {
+                            "D": 148514,
+                            "GK": 69004,
+                            "M": 356332,
+                            "F": 291700
+                        },
+                        "budget": 8035616,
+                        "salary_max": 1912500,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Miguel Almiron"
+                    },
+                    "DC": {
+                        "salary_avg": {
+                            "D": 165416,
+                            "GK": 156209,
+                            "M": 193803,
+                            "F": 196475
+                        },
+                        "budget": 4812135,
+                        "salary_max": 500000,
+                        "salary_max_position": "M-F",
+                        "salary_max_player": "Luciano Acosta"
+                    },
+                    "NYRB": {
+                        "salary_avg": {
+                            "D": 141899,
+                            "GK": 195004,
+                            "M": 218546,
+                            "F": 391839
+                        },
+                        "budget": 6313982,
+                        "salary_max": 1500000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Bradley Wright-Phillips"
+                    },
+                    "PHI": {
+                        "salary_avg": {
+                            "D": 97115,
+                            "GK": 96001,
+                            "M": 320895,
+                            "F": 249826
+                        },
+                        "budget": 6516875,
+                        "salary_max": 1131000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Alejandro Bedoya"
+                    },
+                    "POR": {
+                        "salary_avg": {
+                            "D": 164351,
+                            "GK": 87666,
+                            "M": 458456,
+                            "F": 403501
+                        },
+                        "budget": 9294532,
+                        "salary_max": 2227500,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Diego Valeri"
+                    },
+                    "MTL": {
+                        "salary_avg": {
+                            "D": 209125,
+                            "GK": 103916,
+                            "M": 173651,
+                            "F": 243045
+                        },
+                        "budget": 5074669,
+                        "salary_max": 700000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Matteo Mancosu"
+                    },
+                    "LAFC": {
+                        "salary_avg": {
+                            "M": 59004
+                        },
+                        "budget": 118008,
+                        "salary_max": 65004,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Carlos Alvarez"
+                    },
+                    "DAL": {
+                        "salary_avg": {
+                            "D": 185286,
+                            "GK": 119000,
+                            "M": 245821,
+                            "F": 138875
+                        },
+                        "budget": 5990579,
+                        "salary_max": 784000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Mauro Diaz"
+                    },
+                    "SJ": {
+                        "salary_avg": {
+                            "D": 184431,
+                            "GK": 111668,
+                            "M": 232936,
+                            "F": 318252
+                        },
+                        "budget": 6429566,
+                        "salary_max": 800000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Simon Dawkins"
+                    },
+                    "NYCFC": {
+                        "salary_avg": {
+                            "D": 157208,
+                            "GK": 117088,
+                            "M": 805352,
+                            "F": 1458987
+                        },
+                        "budget": 17370523,
+                        "salary_max": 5610000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "David Villa"
+                    },
+                    "MNUFC": {
+                        "salary_avg": {
+                            "D": 162902,
+                            "GK": 129500,
+                            "M": 221168,
+                            "F": 125000
+                        },
+                        "budget": 4926046,
+                        "salary_max": 550008,
+                        "salary_max_position": "D",
+                        "salary_max_player": "Vadim Demidov"
+                    },
+                    "CHI": {
+                        "salary_avg": {
+                            "D": 163286,
+                            "GK": 123001,
+                            "M": 591401,
+                            "F": 676199
+                        },
+                        "budget": 12272623,
+                        "salary_max": 5400000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Bastian Schweinsteiger"
+                    },
+                    "LA": {
+                        "salary_avg": {
+                            "D": 186308,
+                            "GK": 83543,
+                            "M": 394363,
+                            "F": 569330
+                        },
+                        "budget": 9833666,
+                        "salary_max": 3750000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Giovani Dos Santos"
+                    },
+                    "ORL": {
+                        "salary_avg": {
+                            "D": 173267,
+                            "GK": 108250,
+                            "M": 751125,
+                            "F": 218293
+                        },
+                        "budget": 12382053,
+                        "salary_max": 6660000,
+                        "salary_max_position": "M",
+                        "salary_max_player": " Kaka"
+                    },
+                    "HOU": {
+                        "salary_avg": {
+                            "D": 140881,
+                            "GK": 118770,
+                            "M": 158517,
+                            "F": 310750
+                        },
+                        "budget": 4904049,
+                        "salary_max": 650000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Erick Torres"
+                    },
+                    "VAN": {
+                        "salary_avg": {
+                            "D": 175910,
+                            "GK": 168334,
+                            "M": 219084,
+                            "F": 430000
+                        },
+                        "budget": 7040366,
+                        "salary_max": 1400000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Fredy Montero"
+                    },
+                    "TOR": {
+                        "salary_avg": {
+                            "D": 146763,
+                            "GK": 111669,
+                            "M": 832641,
+                            "F": 1805256
+                        },
+                        "budget": 20074946,
+                        "salary_max": 6000000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Michael Bradley"
+                    },
+                    "RSL": {
+                        "salary_avg": {
+                            "D": 138057,
+                            "GK": 204050,
+                            "M": 286014,
+                            "F": 375377
+                        },
+                        "budget": 6856440,
+                        "salary_max": 1750000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Yura Movsisyan"
+                    },
+                    "COL": {
+                        "salary_avg": {
+                            "D": 87553,
+                            "GK": 738716,
+                            "M": 137783,
+                            "F": 584000
+                        },
+                        "budget": 7254748,
+                        "salary_max": 2000000,
+                        "salary_max_position": "GK",
+                        "salary_max_player": "Tim Howard"
+                    }
+                },
+                "2008": {
+                    "DAL": {
+                        "salary_avg": {
+                            "D": 98911,
+                            "GK": 69333,
+                            "M": 65012,
+                            "F": 81740
+                        },
+                        "budget": 2287050,
+                        "salary_max": 400000,
+                        "salary_max_position": "D",
+                        "salary_max_player": "Dulio Davino"
+                    },
+                    "NE": {
+                        "salary_avg": {
+                            "D": 76453,
+                            "GK": 77150,
+                            "M": 69255,
+                            "F": 102177
+                        },
+                        "budget": 2090045,
+                        "salary_max": 325008,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Taylor Twellman"
+                    },
+                    "SJ": {
+                        "salary_avg": {
+                            "D": 62951,
+                            "GK": 112950,
+                            "M": 101129,
+                            "F": 90466
+                        },
+                        "budget": 2401587,
+                        "salary_max": 330000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Darren Huckerby"
+                    },
+                    "Pool": {
+                        "salary_avg": {
+                            "GK": 22860,
+                            "F": 12900
+                        },
+                        "budget": 127200,
+                        "salary_max": 33000,
+                        "salary_max_position": "GK",
+                        "salary_max_player": "David Monsalve"
+                    },
+                    "CLB": {
+                        "salary_avg": {
+                            "D": 69984,
+                            "GK": 40233,
+                            "M": 61210,
+                            "F": 81941
+                        },
+                        "budget": 2088180,
+                        "salary_max": 250000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Guillermo Barros Schelotto"
+                    },
+                    "CHI": {
+                        "salary_avg": {
+                            "D": 66142,
+                            "GK": 36866,
+                            "M": 369830,
+                            "F": 93124
+                        },
+                        "budget": 4382546,
+                        "salary_max": 2492316,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Cuauhtemoc Blanco"
+                    },
+                    "SEA": {
+                        "salary_avg": {
+                            "M": 58500
+                        },
+                        "budget": 117000,
+                        "salary_max": 84000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Sebastian Le Toux"
+                    },
+                    "LA": {
+                        "salary_avg": {
+                            "D": 64745,
+                            "GK": 39725,
+                            "M": 662577,
+                            "F": 176472
+                        },
+                        "budget": 8069604,
+                        "salary_max": 5500000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "David Beckham"
+                    },
+                    "DC": {
+                        "salary_avg": {
+                            "D": 59200,
+                            "GK": 77940,
+                            "M": 183826,
+                            "F": 265250
+                        },
+                        "budget": 4335770,
+                        "salary_max": 1500000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Marcelo Gallardo"
+                    },
+                    "TFC": {
+                        "salary_avg": {
+                            "D": 73355,
+                            "GK": 93000,
+                            "M": 113214,
+                            "F": 102310
+                        },
+                        "budget": 2354874,
+                        "salary_max": 350000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Carlos Ruiz"
+                    },
+                    "HOU": {
+                        "salary_avg": {
+                            "D": 78499,
+                            "GK": 79498,
+                            "M": 85458,
+                            "F": 96150
+                        },
+                        "budget": 2386656,
+                        "salary_max": 324999,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Dwayne DeRosario"
+                    },
+                    "KC": {
+                        "salary_avg": {
+                            "D": 55316,
+                            "GK": 65300,
+                            "M": 58200,
+                            "F": 219325
+                        },
+                        "budget": 2314178,
+                        "salary_max": 720000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Claudio Lopez"
+                    },
+                    "RSL": {
+                        "salary_avg": {
+                            "D": 73837,
+                            "GK": 59733,
+                            "M": 94528,
+                            "F": 60229
+                        },
+                        "budget": 2171090,
+                        "salary_max": 240000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Javier Morales"
+                    },
+                    "COL": {
+                        "salary_avg": {
+                            "D": 62042,
+                            "GK": 33672,
+                            "M": 97075,
+                            "F": 108102
+                        },
+                        "budget": 2318744,
+                        "salary_max": 385000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Christian Gomez"
+                    },
+                    "NY": {
+                        "salary_avg": {
+                            "D": 60034,
+                            "GK": 43450,
+                            "M": 64500,
+                            "F": 293740
+                        },
+                        "budget": 3190516,
+                        "salary_max": 1500000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Juan Pablo Angel"
+                    },
+                    "CHV": {
+                        "salary_avg": {
+                            "D": 71219,
+                            "GK": 46218,
+                            "M": 87924,
+                            "F": 65483
+                        },
+                        "budget": 2294448,
+                        "salary_max": 255000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Ante Razov"
+                    }
+                },
+                "2009": {
+                    "DAL": {
+                        "salary_avg": {
+                            "D": 61754,
+                            "GK": 81550,
+                            "M": 102989,
+                            "F": 156717
+                        },
+                        "budget": 2346619,
+                        "salary_max": 300000,
+                        "salary_max_position": "M-F",
+                        "salary_max_player": "David Ferreira"
+                    },
+                    "NE": {
+                        "salary_avg": {
+                            "D": 84626,
+                            "GK": 75814,
+                            "M": 91931,
+                            "F": 148325
+                        },
+                        "budget": 2587003,
+                        "salary_max": 425000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Shalrie Joseph"
+                    },
+                    "SJ": {
+                        "salary_avg": {
+                            "D": 51866,
+                            "GK": 79366,
+                            "M": 89767,
+                            "F": 160442
+                        },
+                        "budget": 2003760,
+                        "salary_max": 360000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Darren Huckerby"
+                    },
+                    "Pool": {
+                        "salary_avg": {
+                            "GK": 31220
+                        },
+                        "budget": 156100,
+                        "salary_max": 34000,
+                        "salary_max_position": "GK",
+                        "salary_max_player": "Miguel Benitez"
+                    },
+                    "CLB": {
+                        "salary_avg": {
+                            "D": 100191,
+                            "GK": 48550,
+                            "M": 142547,
+                            "F": 157373
+                        },
+                        "budget": 2573342,
+                        "salary_max": 650000,
+                        "salary_max_position": "F-M",
+                        "salary_max_player": "Guillermo Barros Schelotto"
+                    },
+                    "KC": {
+                        "salary_avg": {
+                            "D": 70785,
+                            "GK": 73250,
+                            "M": 65875,
+                            "F": 95056
+                        },
+                        "budget": 2084923,
+                        "salary_max": 220000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Davy Arnaud"
+                    },
+                    "SEA": {
+                        "salary_avg": {
+                            "D": 59139,
+                            "GK": 127166,
+                            "M": 185745,
+                            "F": 112501
+                        },
+                        "budget": 3221212,
+                        "salary_max": 1300000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Fredrik Ljungberg"
+                    },
+                    "LA": {
+                        "salary_avg": {
+                            "D": 77142,
+                            "GK": 95670,
+                            "M": 994017,
+                            "F": 178283
+                        },
+                        "budget": 8531425,
+                        "salary_max": 5500000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "David Beckham"
+                    },
+                    "DC": {
+                        "salary_avg": {
+                            "D": 57400,
+                            "GK": 27400,
+                            "M": 86363,
+                            "F": 170672
+                        },
+                        "budget": 2981654,
+                        "salary_max": 720000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Luciano Emilio"
+                    },
+                    "TFC": {
+                        "salary_avg": {
+                            "D": 78986,
+                            "GK": 52300,
+                            "M": 315814,
+                            "F": 143166
+                        },
+                        "budget": 3577074,
+                        "salary_max": 909600,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Julian de Guzman"
+                    },
+                    "HOU": {
+                        "salary_avg": {
+                            "D": 117636,
+                            "GK": 82250,
+                            "M": 92985,
+                            "F": 86754
+                        },
+                        "budget": 2489703,
+                        "salary_max": 248050,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Ricardo Clark"
+                    },
+                    "CHI": {
+                        "salary_avg": {
+                            "D": 61027,
+                            "GK": 84500,
+                            "M": 473477,
+                            "F": 108011
+                        },
+                        "budget": 4721583,
+                        "salary_max": 2769240,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Cuauhtemoc Blanco"
+                    },
+                    "RSL": {
+                        "salary_avg": {
+                            "D": 87740,
+                            "GK": 71333,
+                            "M": 85084,
+                            "F": 58729
+                        },
+                        "budget": 1945371,
+                        "salary_max": 160650,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Kyle Beckerman"
+                    },
+                    "COL": {
+                        "salary_avg": {
+                            "D": 90420,
+                            "GK": 67657,
+                            "M": 110607,
+                            "F": 100351
+                        },
+                        "budget": 2228536,
+                        "salary_max": 255000,
+                        "salary_max_position": "M-D",
+                        "salary_max_player": "Pablo Mastroeni"
+                    },
+                    "NY": {
+                        "salary_avg": {
+                            "D": 66075,
+                            "GK": 78999,
+                            "M": 66285,
+                            "F": 359020
+                        },
+                        "budget": 3097599,
+                        "salary_max": 1500000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Juan Pablo Angel"
+                    },
+                    "CHV": {
+                        "salary_avg": {
+                            "D": 92462,
+                            "GK": 39650,
+                            "M": 88658,
+                            "F": 71117
+                        },
+                        "budget": 2353283,
+                        "salary_max": 170000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Sacha Kljestan"
+                    }
+                },
+                "2013": {
+                    "DAL": {
+                        "salary_avg": {
+                            "D": 98529,
+                            "GK": 71350,
+                            "M": 140989,
+                            "F": 232700
+                        },
+                        "budget": 4076343,
+                        "salary_max": 625000,
+                        "salary_max_position": "M-F",
+                        "salary_max_player": "David Ferreira"
+                    },
+                    "NE": {
+                        "salary_avg": {
+                            "D": 78189,
+                            "GK": 93376,
+                            "M": 93723,
+                            "F": 113839
+                        },
+                        "budget": 2742432,
+                        "salary_max": 275000,
+                        "salary_max_position": "M-F",
+                        "salary_max_player": "Juan Toja"
+                    },
+                    "SJ": {
+                        "salary_avg": {
+                            "D": 110453,
+                            "GK": 96533,
+                            "M": 135229,
+                            "F": 94232
+                        },
+                        "budget": 3558741,
+                        "salary_max": 550000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Chris Wondolowski"
+                    },
+                    "CLB": {
+                        "salary_avg": {
+                            "D": 118340,
+                            "GK": 57948,
+                            "M": 125102,
+                            "F": 128963
+                        },
+                        "budget": 3169668,
+                        "salary_max": 440000,
+                        "salary_max_position": "M-F",
+                        "salary_max_player": "Federico Higuain"
+                    },
+                    "RSL": {
+                        "salary_avg": {
+                            "D": 98252,
+                            "GK": 92906,
+                            "M": 125895,
+                            "F": 119321
+                        },
+                        "budget": 3503642,
+                        "salary_max": 360000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Alvaro Saborio"
+                    },
+                    "CHI": {
+                        "salary_avg": {
+                            "D": 121599,
+                            "GK": 67208,
+                            "M": 170354,
+                            "F": 124650
+                        },
+                        "budget": 4465170,
+                        "salary_max": 768000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Egidio Rios"
+                    },
+                    "SEA": {
+                        "salary_avg": {
+                            "D": 100640,
+                            "GK": 105500,
+                            "M": 92405,
+                            "F": 868202
+                        },
+                        "budget": 9767100,
+                        "salary_max": 4913004,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Clint Dempsey"
+                    },
+                    "POOL": {
+                        "salary_avg": {
+                            "GK": 35125
+                        },
+                        "budget": 70250,
+                        "salary_max": 35125,
+                        "salary_max_position": "GK",
+                        "salary_max_player": "Doug Herrick"
+                    },
+                    "LA": {
+                        "salary_avg": {
+                            "D": 110905,
+                            "GK": 82375,
+                            "M": 99475,
+                            "F": 865390
+                        },
+                        "budget": 9206430,
+                        "salary_max": 4000000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Robbie Keane"
+                    },
+                    "DC": {
+                        "salary_avg": {
+                            "D": 107748,
+                            "GK": 56000,
+                            "M": 140927,
+                            "F": 122212
+                        },
+                        "budget": 3232138,
+                        "salary_max": 600000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Dwayne DeRosario"
+                    },
+                    "POR": {
+                        "salary_avg": {
+                            "D": 90752,
+                            "GK": 128204,
+                            "M": 130246,
+                            "F": 119332
+                        },
+                        "budget": 3466000,
+                        "salary_max": 400000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Diego Valeri"
+                    },
+                    "PHI": {
+                        "salary_avg": {
+                            "D": 145100,
+                            "GK": 78250,
+                            "M": 116182,
+                            "F": 83146
+                        },
+                        "budget": 3322942,
+                        "salary_max": 495000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Jose Kleberson"
+                    },
+                    "MTL": {
+                        "salary_avg": {
+                            "D": 130180,
+                            "GK": 102208,
+                            "M": 105003,
+                            "F": 227572
+                        },
+                        "budget": 4263316,
+                        "salary_max": 1000008,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Marco Di Vaio"
+                    },
+                    "HOU": {
+                        "salary_avg": {
+                            "D": 113604,
+                            "GK": 103833,
+                            "M": 135987,
+                            "F": 103979
+                        },
+                        "budget": 3184833,
+                        "salary_max": 325000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Brad Davis"
+                    },
+                    "VAN": {
+                        "salary_avg": {
+                            "D": 135391,
+                            "GK": 107906,
+                            "M": 105611,
+                            "F": 198885
+                        },
+                        "budget": 4279508,
+                        "salary_max": 1114992,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Kenny Miller"
+                    },
+                    "KC": {
+                        "salary_avg": {
+                            "D": 82916,
+                            "GK": 112278,
+                            "M": 126520,
+                            "F": 135214
+                        },
+                        "budget": 3205085,
+                        "salary_max": 350000,
+                        "salary_max_position": "F-M",
+                        "salary_max_player": "Graham Zusi"
+                    },
+                    "TOR": {
+                        "salary_avg": {
+                            "D": 87249,
+                            "GK": 71125,
+                            "M": 94171,
+                            "F": 234321
+                        },
+                        "budget": 3610447,
+                        "salary_max": 1250000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Danny Koevermans"
+                    },
+                    "COL": {
+                        "salary_avg": {
+                            "D": 89836,
+                            "GK": 95041,
+                            "M": 83701,
+                            "F": 173833
+                        },
+                        "budget": 3066900,
+                        "salary_max": 275000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Edson Buddle"
+                    },
+                    "NY": {
+                        "salary_avg": {
+                            "D": 149654,
+                            "GK": 55406,
+                            "M": 395168,
+                            "F": 608959
+                        },
+                        "budget": 9981937,
+                        "salary_max": 3750000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Thierry Henry"
+                    },
+                    "CHV": {
+                        "salary_avg": {
+                            "D": 107384,
+                            "GK": 99666,
+                            "M": 69407,
+                            "F": 73894
+                        },
+                        "budget": 2409807,
+                        "salary_max": 228000,
+                        "salary_max_position": "D",
+                        "salary_max_player": "Carlos Bocanegra"
+                    }
+                },
+                "2014": {
+                    "CLB": {
+                        "salary_avg": {
+                            "D": 126732,
+                            "GK": 77441,
+                            "M": 115665,
+                            "F": 140532
+                        },
+                        "budget": 3176361,
+                        "salary_max": 580000,
+                        "salary_max_position": "M-F",
+                        "salary_max_player": "Federico Higuain"
+                    },
+                    "NE": {
+                        "salary_avg": {
+                            "D": 143669,
+                            "GK": 60276,
+                            "M": 347929,
+                            "F": 116454
+                        },
+                        "budget": 6362933,
+                        "salary_max": 3000000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Jermaine Jones"
+                    },
+                    "KC": {
+                        "salary_avg": {
+                            "D": 151695,
+                            "GK": 91666,
+                            "M": 157944,
+                            "F": 176878
+                        },
+                        "budget": 4143312,
+                        "salary_max": 600000,
+                        "salary_max_position": "D",
+                        "salary_max_player": "Matt Besler"
+                    },
+                    "SEA": {
+                        "salary_avg": {
+                            "D": 94829,
+                            "GK": 87833,
+                            "M": 114118,
+                            "F": 810130
+                        },
+                        "budget": 9396634,
+                        "salary_max": 4913004,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Clint Dempsey"
+                    },
+                    "DC": {
+                        "salary_avg": {
+                            "D": 99541,
+                            "GK": 65883,
+                            "M": 118752,
+                            "F": 194403
+                        },
+                        "budget": 3471746,
+                        "salary_max": 505000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Eddie Johnson"
+                    },
+                    "POR": {
+                        "salary_avg": {
+                            "D": 195969,
+                            "GK": 124833,
+                            "M": 153000,
+                            "F": 218570
+                        },
+                        "budget": 5283726,
+                        "salary_max": 1200000,
+                        "salary_max_position": "D",
+                        "salary_max_player": "Liam Ridgewell"
+                    },
+                    "PHI": {
+                        "salary_avg": {
+                            "D": 112401,
+                            "GK": 145000,
+                            "M": 156929,
+                            "F": 113468
+                        },
+                        "budget": 4073098,
+                        "salary_max": 650000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Maurice Edu"
+                    },
+                    "TOR": {
+                        "salary_avg": {
+                            "D": 115732,
+                            "GK": 78834,
+                            "M": 818520,
+                            "F": 873348
+                        },
+                        "budget": 15686628,
+                        "salary_max": 6000000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Michael Bradley"
+                    },
+                    "MTL": {
+                        "salary_avg": {
+                            "D": 137032,
+                            "GK": 115775,
+                            "M": 110047,
+                            "F": 298572
+                        },
+                        "budget": 5080914,
+                        "salary_max": 1500000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Marco Di Vaio"
+                    },
+                    "CHV": {
+                        "salary_avg": {
+                            "D": 146550,
+                            "GK": 124127,
+                            "M": 129100,
+                            "F": 65185
+                        },
+                        "budget": 3077432,
+                        "salary_max": 400000,
+                        "salary_max_position": "D-M",
+                        "salary_max_player": "Nigel Reo-Coker"
+                    },
+                    "DAL": {
+                        "salary_avg": {
+                            "D": 104002,
+                            "GK": 104500,
+                            "M": 114458,
+                            "F": 192251
+                        },
+                        "budget": 4041037,
+                        "salary_max": 625000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Andres Escobar"
+                    },
+                    "SJ": {
+                        "salary_avg": {
+                            "D": 120750,
+                            "GK": 86041,
+                            "M": 174519,
+                            "F": 106108
+                        },
+                        "budget": 3957076,
+                        "salary_max": 600000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Chris Wondolowski"
+                    },
+                    "NYCFC": {
+                        "salary_avg": {
+                            "D": 55000,
+                            "GK": 48504,
+                            "M": 147500,
+                            "F": 60000
+                        },
+                        "budget": 458504,
+                        "salary_max": 180000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Andrew Jacobson"
+                    },
+                    "CHI": {
+                        "salary_avg": {
+                            "D": 133415,
+                            "GK": 124166,
+                            "M": 88546,
+                            "F": 143666
+                        },
+                        "budget": 3529746,
+                        "salary_max": 350000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Mike Magee"
+                    },
+                    "POOL": {
+                        "salary_avg": {
+                            "GK": 36504
+                        },
+                        "budget": 36504,
+                        "salary_max": 36504,
+                        "salary_max_position": "GK",
+                        "salary_max_player": "Daniel Withrow"
+                    },
+                    "LA": {
+                        "salary_avg": {
+                            "D": 183797,
+                            "GK": 81275,
+                            "M": 136282,
+                            "F": 865772
+                        },
+                        "budget": 12375473,
+                        "salary_max": 4500000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Robbie Keane"
+                    },
+                    "ORL": {
+                        "salary_avg": {
+                            "D": 36500,
+                            "M": 1704625
+                        },
+                        "budget": 6855000,
+                        "salary_max": 6660000,
+                        "salary_max_position": "M",
+                        "salary_max_player": " Kaka"
+                    },
+                    "NY": {
+                        "salary_avg": {
+                            "D": 117689,
+                            "GK": 68250,
+                            "M": 435965,
+                            "F": 891729
+                        },
+                        "budget": 10268811,
+                        "salary_max": 3750000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Thierry Henry"
+                    },
+                    "HOU": {
+                        "salary_avg": {
+                            "D": 197000,
+                            "GK": 108834,
+                            "M": 156704,
+                            "F": 125803
+                        },
+                        "budget": 4027369,
+                        "salary_max": 750000,
+                        "salary_max_position": "D",
+                        "salary_max_player": "DaMarcus Beasley"
+                    },
+                    "VAN": {
+                        "salary_avg": {
+                            "D": 115452,
+                            "GK": 119501,
+                            "M": 227221,
+                            "F": 72331
+                        },
+                        "budget": 4542729,
+                        "salary_max": 1190000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Pedro Morales"
+                    },
+                    "RSL": {
+                        "salary_avg": {
+                            "D": 111255,
+                            "GK": 103441,
+                            "M": 144350,
+                            "F": 136444
+                        },
+                        "budget": 3647515,
+                        "salary_max": 360000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Alvaro Saborio"
+                    },
+                    "COL": {
+                        "salary_avg": {
+                            "D": 102759,
+                            "GK": 53833,
+                            "M": 80216,
+                            "F": 173137
+                        },
+                        "budget": 3007541,
+                        "salary_max": 325000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Edson Buddle"
+                    }
+                },
+                "2007": {
+                    "CLB": {
+                        "salary_avg": {
+                            "D": 78000,
+                            "GK": 26190,
+                            "M": 60979,
+                            "F": 70606
+                        },
+                        "budget": 1889550,
+                        "salary_max": 165000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Eddie Gaven"
+                    },
+                    "DAL": {
+                        "salary_avg": {
+                            "D": 49026,
+                            "GK": 116166,
+                            "M": 120633,
+                            "F": 89285
+                        },
+                        "budget": 2790739,
+                        "salary_max": 872736,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Denilson De Oliveira"
+                    },
+                    "Pool": {
+                        "salary_avg": {
+                            "GK": 20775
+                        },
+                        "budget": 83100,
+                        "salary_max": 30000,
+                        "salary_max_position": "GK",
+                        "salary_max_player": "David Monsalve"
+                    },
+                    "NE": {
+                        "salary_avg": {
+                            "D": 71358,
+                            "GK": 70966,
+                            "M": 40207,
+                            "F": 92009
+                        },
+                        "budget": 1850848,
+                        "salary_max": 325008,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Taylor Twellman"
+                    },
+                    "KC": {
+                        "salary_avg": {
+                            "D": 78857,
+                            "GK": 64300,
+                            "M": 55029,
+                            "F": 103222
+                        },
+                        "budget": 2441925,
+                        "salary_max": 750000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Eddie Johnson"
+                    },
+                    "LA": {
+                        "salary_avg": {
+                            "D": 73362,
+                            "GK": 79876,
+                            "M": 578695,
+                            "F": 196124
+                        },
+                        "budget": 8229548,
+                        "salary_max": 5500000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "David Beckham"
+                    },
+                    "DC": {
+                        "salary_avg": {
+                            "D": 70072,
+                            "GK": 44633,
+                            "M": 71291,
+                            "F": 95297
+                        },
+                        "budget": 2101315,
+                        "salary_max": 265000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Luciano Emilio"
+                    },
+                    "TFC": {
+                        "salary_avg": {
+                            "D": 75225,
+                            "GK": 57566,
+                            "M": 89510,
+                            "F": 122500
+                        },
+                        "budget": 2310050,
+                        "salary_max": 300000,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Carl Robinson"
+                    },
+                    "HOU": {
+                        "salary_avg": {
+                            "D": 91579,
+                            "GK": 77100,
+                            "M": 78746,
+                            "F": 98509
+                        },
+                        "budget": 2350046,
+                        "salary_max": 324999,
+                        "salary_max_position": "M",
+                        "salary_max_player": "Dwayne DeRosario"
+                    },
+                    "CHI": {
+                        "salary_avg": {
+                            "D": 67421,
+                            "GK": 34416,
+                            "M": 82840,
+                            "F": 483204
+                        },
+                        "budget": 4412517,
+                        "salary_max": 2492316,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Cuauhtemoc Blanco"
+                    },
+                    "RSL": {
+                        "salary_avg": {
+                            "D": 68722,
+                            "GK": 45608,
+                            "M": 66371,
+                            "F": 57056
+                        },
+                        "budget": 1798530,
+                        "salary_max": 265000,
+                        "salary_max_position": "D",
+                        "salary_max_player": "Eddie Pope"
+                    },
+                    "COL": {
+                        "salary_avg": {
+                            "D": 77840,
+                            "GK": 33500,
+                            "M": 85244,
+                            "F": 101881
+                        },
+                        "budget": 2181153,
+                        "salary_max": 280000,
+                        "salary_max_position": "M-D",
+                        "salary_max_player": "Pablo Mastroeni"
+                    },
+                    "NY": {
+                        "salary_avg": {
+                            "D": 44232,
+                            "GK": 92633,
+                            "M": 152877,
+                            "F": 199848
+                        },
+                        "budget": 4360735,
+                        "salary_max": 1500000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Juan Pablo Angel"
+                    },
+                    "CHV": {
+                        "salary_avg": {
+                            "D": 55426,
+                            "GK": 39209,
+                            "M": 61416,
+                            "F": 68516
+                        },
+                        "budget": 1678269,
+                        "salary_max": 245000,
+                        "salary_max_position": "F",
+                        "salary_max_player": "Ante Razov"
+                    }
                 }
             }
         }
-    }
-];
+    ];
 
 export default data;

--- a/src/SalaryDonut.js
+++ b/src/SalaryDonut.js
@@ -3,20 +3,20 @@ import { Chart } from 'react-google-charts';
 import './SalaryDonut.css'
 
 class SalaryDonut extends Component {
-    render(){
+    render() {
 
         var salaries = [];
         salaries.push(["Position", "Salary"]);
         Object.keys(this.props.positions).map(position =>
             salaries.push([position, this.props.positions[position]])
         )
-        return(
+        return (
             <Chart
                 chartType="PieChart"
                 data={salaries}
                 options={{
                     title: "Average Salary per Position",
-                    chartArea: {width: '50%'},
+                    chartArea: { width: '50%' },
                     isStacked: true,
                     hAxis: {
                         title: 'Budget per row of positions',
@@ -26,7 +26,7 @@ class SalaryDonut extends Component {
                         title: 'Year'
                     }
                 }}
-                graph_id={"AvgSalary"+this.props.team}
+                graph_id={"AvgSalary" + this.props.team}
                 width="100%"
                 height="400px"
                 legend_toggle

--- a/src/TeamCard.js
+++ b/src/TeamCard.js
@@ -4,10 +4,10 @@ import './TeamCard.css';
 
 class TeamCard extends Component {
     render() {
-        var budget = "$"+this.props.budget.toLocaleString();
-        var salary = "$"+this.props.salary.toLocaleString();
+        var budget = "$" + this.props.budget.toLocaleString();
+        var salary = "$" + this.props.salary.toLocaleString();
 
-        return(
+        return (
             <div className="team">
                 <h3>{this.props.team}</h3>
                 <p>Appr. Player Budget: {budget}</p>

--- a/src/registerServiceWorker.js
+++ b/src/registerServiceWorker.js
@@ -10,12 +10,12 @@
 
 const isLocalhost = Boolean(
   window.location.hostname === 'localhost' ||
-    // [::1] is the IPv6 localhost address.
-    window.location.hostname === '[::1]' ||
-    // 127.0.0.1/8 is considered localhost for IPv4.
-    window.location.hostname.match(
-      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
-    )
+  // [::1] is the IPv6 localhost address.
+  window.location.hostname === '[::1]' ||
+  // 127.0.0.1/8 is considered localhost for IPv4.
+  window.location.hostname.match(
+    /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
+  )
 );
 
 export default function register() {


### PR DESCRIPTION
- formatted using Prettier
- tested
- not deployed as there is no functional change